### PR TITLE
Feat : JWT provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 
-application-db.yml
+application-secret.yml

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.projectlombok:lombok:1.18.22'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -38,6 +39,11 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // JWT 라이브러리
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/generated/com/wanted/sns_feed_service/feed/entity/QFeed.java
+++ b/src/main/generated/com/wanted/sns_feed_service/feed/entity/QFeed.java
@@ -1,0 +1,55 @@
+package com.wanted.sns_feed_service.feed.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QFeed is a Querydsl query type for Feed
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QFeed extends EntityPathBase<Feed> {
+
+    private static final long serialVersionUID = 902296570L;
+
+    public static final QFeed feed = new QFeed("feed");
+
+    public final StringPath content = createString("content");
+
+    public final StringPath contentId = createString("contentId");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> likeCount = createNumber("likeCount", Integer.class);
+
+    public final NumberPath<Integer> shareCount = createNumber("shareCount", Integer.class);
+
+    public final StringPath title = createString("title");
+
+    public final EnumPath<Type> type = createEnum("type", Type.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> viewCount = createNumber("viewCount", Integer.class);
+
+    public QFeed(String variable) {
+        super(Feed.class, forVariable(variable));
+    }
+
+    public QFeed(Path<? extends Feed> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QFeed(PathMetadata metadata) {
+        super(Feed.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/wanted/sns_feed_service/member/entity/QMember.java
+++ b/src/main/generated/com/wanted/sns_feed_service/member/entity/QMember.java
@@ -1,0 +1,45 @@
+package com.wanted.sns_feed_service.member.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 1856399794L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final StringPath accessToken = createString("accessToken");
+
+    public final StringPath account = createString("account");
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath password = createString("password");
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/wanted/sns_feed_service/jwt/JwtProvider.java
+++ b/src/main/java/com/wanted/sns_feed_service/jwt/JwtProvider.java
@@ -1,0 +1,30 @@
+package com.wanted.sns_feed_service.jwt;
+import java.util.Base64;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtProvider {
+	private SecretKey cachedSecretKey;
+
+	@Value("${custom.jwt.secretKey}")
+	private String secretKeyPlain;
+
+	private SecretKey _getSecretKey() {
+		// 시크릿 키 객체 생성 : 시크릿 키 평문 Base64 인코딩 -> hmac 인코딩
+		String keyBase64Encoded = Base64.getEncoder().encodeToString(secretKeyPlain.getBytes());
+		return Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
+	}
+
+	// 시크릿키 객체가 있으면 저장된거 사용, 없으면 생성
+	public SecretKey getSecretKey() {
+		if (cachedSecretKey == null) cachedSecretKey = _getSecretKey();
+
+		return cachedSecretKey;
+	}
+}

--- a/src/main/java/com/wanted/sns_feed_service/jwt/JwtProvider.java
+++ b/src/main/java/com/wanted/sns_feed_service/jwt/JwtProvider.java
@@ -1,11 +1,17 @@
 package com.wanted.sns_feed_service.jwt;
 import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
 
 import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.wanted.sns_feed_service.util.Ut;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
 @Component
@@ -26,5 +32,44 @@ public class JwtProvider {
 		if (cachedSecretKey == null) cachedSecretKey = _getSecretKey();
 
 		return cachedSecretKey;
+	}
+
+	// 토큰에 들어갈 정보와 만료 시간을 받으면 토큰을 생성하는 메서드
+	public String genToken(Map<String, Object> claims, int seconds) {
+		long now = new Date().getTime();
+		Date accessTokenExpiresIn = new Date(now + 1000L * seconds);
+
+		return Jwts.builder()
+			.claim("body", Ut.json.toStr(claims))
+			.setExpiration(accessTokenExpiresIn)
+			// 추후 알고리즘과 비밀키를 사용하여 서버가 서명했는지 검증함
+			.signWith(getSecretKey(), SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	// 토큰이 유효한지 검사하는 메서드
+	public boolean verify(String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(getSecretKey())
+				.build()
+				.parseClaimsJws(token);
+		} catch (Exception e) {
+			return false;
+		}
+
+		return true;
+	}
+
+	// 토큰으로부터 정보를 추출하는 메서드
+	public Map<String, Object> getClaims(String token) {
+		String body = Jwts.parserBuilder()
+			.setSigningKey(getSecretKey())
+			.build()
+			.parseClaimsJws(token)
+			.getBody()
+			.get("body", String.class);
+
+		return Ut.json.toMap(body);
 	}
 }

--- a/src/main/java/com/wanted/sns_feed_service/util/Ut.java
+++ b/src/main/java/com/wanted/sns_feed_service/util/Ut.java
@@ -1,0 +1,30 @@
+package com.wanted.sns_feed_service.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class Ut {
+	public static class json {
+		// map을 Json 형태 변환 매서드
+		public static Object toStr(Map<String, Object> map) {
+			try {
+				// Jackson 라이브러리 ObjectMapper 클래스 사용하여 map 객체를 Json형태
+				// Java <-> Json 처리 작업 간단하게 해주는 클래스
+				return new ObjectMapper().writeValueAsString(map);
+			} catch (JsonProcessingException e) {
+				return null;
+			}
+		}
+		// json 형태 데이터를 map 형태로 변환
+		public static Map<String, Object> toMap(String jsonStr) {
+			try {
+				return new ObjectMapper().readValue(jsonStr, LinkedHashMap.class);
+			} catch (JsonProcessingException e) {
+				return null;
+			}
+		}
+	}
+}

--- a/src/main/resources/application-db.yml.template
+++ b/src/main/resources/application-db.yml.template
@@ -1,6 +1,0 @@
-spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/'데이터베이스이름'
-    username: '사용자 이름'
-    password: '사용자 비밀번호'

--- a/src/main/resources/application-secret.yml.template
+++ b/src/main/resources/application-secret.yml.template
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/'디비명'
+    username: '계정정보'
+    password: '암호'
+
+custom:
+  jwt:
+    secretKey: '시크릿키'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   profiles:
     active: dev
-    include: db
+    include: secret
   jpa:
     hibernate:
       ddl-auto: create
@@ -19,3 +19,7 @@ logging:
     com.wanted.sns_feed_service: DEBUG  #????
     org.hibernate.orm.jdbc.bind: TRACE # SQL ???? ???(?? ??? ?? ??)
     org.hibernate.orm.jdbc.extract: TRACE #??? ??? ???
+
+custom:
+  jwt:
+    secretKey:

--- a/src/test/java/com/wanted/sns_feed_service/jwt/JwtTests.java
+++ b/src/test/java/com/wanted/sns_feed_service/jwt/JwtTests.java
@@ -1,7 +1,8 @@
-package com.wanted.sns_feed_service.jwt_spring;
+package com.wanted.sns_feed_service.jwt;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,6 +23,9 @@ class JwtTests {
 	@Value("${custom.jwt.secretKey}")
 	private String secretKeyPlain;
 
+	@Autowired
+	private JwtProvider jwtProvider;
+
 	@Test
 	@DisplayName("secretKey 키가 존재해야한다.")
 	void t1() {
@@ -37,5 +41,22 @@ class JwtTests {
 		SecretKey secretKey = Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
 
 		assertThat(secretKey).isNotNull();
+	}
+
+	@Test
+	@DisplayName("JwtProvider 객체로 SecretKey 객체를 생성할 수 있다.")
+	void t3() {
+		SecretKey secretKey = jwtProvider.getSecretKey();
+
+		assertThat(secretKey).isNotNull();
+	}
+
+	@Test
+	@DisplayName("SecretKey 객체는 단 한번만 생성되어야 한다.")
+	void t4() {
+		SecretKey secretKey1 = jwtProvider.getSecretKey();
+		SecretKey secretKey2 = jwtProvider.getSecretKey();
+
+		assertThat(secretKey1 == secretKey2).isTrue();
 	}
 }

--- a/src/test/java/com/wanted/sns_feed_service/jwt/JwtTests.java
+++ b/src/test/java/com/wanted/sns_feed_service/jwt/JwtTests.java
@@ -10,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.crypto.SecretKey;
 
@@ -58,5 +60,53 @@ class JwtTests {
 		SecretKey secretKey2 = jwtProvider.getSecretKey();
 
 		assertThat(secretKey1 == secretKey2).isTrue();
+	}
+
+	@Test
+	@DisplayName("accessToken 을 얻는다.")
+	void t5() {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("id", 1L);
+		claims.put("username", "admin");
+
+		// 지금으로부터 5시간의 유효기간을 가지는 토큰을 생성
+		String accessToken = jwtProvider.genToken(claims, 60 * 60 * 5);
+
+		System.out.println("accessToken : " + accessToken);
+
+		assertThat(accessToken).isNotNull();
+	}
+
+	@Test
+	@DisplayName("accessToken 을 통해서 claims 를 얻을 수 있다.")
+	void t6() {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("id", 1L);
+		claims.put("username", "admin");
+
+		// 지금으로부터 5시간의 유효기간을 가지는 토큰을 생성
+		String accessToken = jwtProvider.genToken(claims, 60 * 60 * 5);
+
+		System.out.println("accessToken : " + accessToken);
+
+		assertThat(jwtProvider.verify(accessToken)).isTrue();
+
+		Map<String, Object> claimsFromToken = jwtProvider.getClaims(accessToken);
+		System.out.println("claimsFromToken : " + claimsFromToken);
+	}
+
+	@Test
+	@DisplayName("만료된 토큰을 유효하지 않다.")
+	void t7() {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("id", 1L);
+		claims.put("username", "admin");
+
+		// 지금으로부터 5시간의 유효기간을 가지는 토큰을 생성
+		String accessToken = jwtProvider.genToken(claims, -1);
+
+		System.out.println("accessToken : " + accessToken);
+
+		assertThat(jwtProvider.verify(accessToken)).isFalse();
 	}
 }

--- a/src/test/java/com/wanted/sns_feed_service/jwt/JwtTests.java
+++ b/src/test/java/com/wanted/sns_feed_service/jwt/JwtTests.java
@@ -102,7 +102,7 @@ class JwtTests {
 		claims.put("id", 1L);
 		claims.put("username", "admin");
 
-		// 지금으로부터 5시간의 유효기간을 가지는 토큰을 생성
+		// 만료 기간을 현재 시간보다 -1초로 설정 -> 만료 토큰 생성
 		String accessToken = jwtProvider.genToken(claims, -1);
 
 		System.out.println("accessToken : " + accessToken);

--- a/src/test/java/com/wanted/sns_feed_service/jwt_spring/JwtTests.java
+++ b/src/test/java/com/wanted/sns_feed_service/jwt_spring/JwtTests.java
@@ -1,0 +1,41 @@
+package com.wanted.sns_feed_service.jwt_spring;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Base64;
+
+import javax.crypto.SecretKey;
+
+import io.jsonwebtoken.security.Keys;
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class JwtTests {
+	@Value("${custom.jwt.secretKey}")
+	private String secretKeyPlain;
+
+	@Test
+	@DisplayName("secretKey 키가 존재해야한다.")
+	void t1() {
+		assertThat(secretKeyPlain).isNotNull();
+	}
+
+	@Test
+	@DisplayName("sercretKey 원문으로 hmac 암호화 알고리즘에 맞는 SecretKey 객체를 만들 수 있다.")
+	void t2() {
+		// 키를 Base64 인코딩 한다.
+		String keyBase64Encoded = Base64.getEncoder().encodeToString(secretKeyPlain.getBytes());
+		// Base64 인코딩된 키를 이용하여 SecretKey 객체를 만든다.
+		SecretKey secretKey = Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
+
+		assertThat(secretKey).isNotNull();
+	}
+}


### PR DESCRIPTION
## 🌿 PR타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]

close #3 

### 📑 개요

- JW 토큰을 발행하는 메서드를 구현합니다.
- JWT 발행 순서
  1. 시크릿 키 원문을 사용하여 Secret Key 객체 생성.
  2. JWT에 포함될 정보(Claim)를 구성.
  3. 토큰 발행.(시크릿키 객체로 암호화)
 - [JWT 관련 정리](https://github.com/CheorHyeon/Jwt_Spring)

###  🧷 변경사항

-  **application-db.yml => application-secret.yml 파일명 변경**
   - [x] 토큰 발급을 위한 Secret Key 설정을 추가하였고, 별도 프로필 만들기 보다는 secret으로 합쳤습니다.

- QueryDSL Q엔티티들은 의존성 주입 하면서 자동으로 생겼습니다.

- **src/main/java/com/wanted/sns_feed_service/jwt/JwtProvider.java**
  - [x] genToken : 토큰에 들어갈 정보와 만료 시간을 받으면 토큰을 생성하는 메서드 입니다. 
  - [x] verify : 토큰이 유효한 토큰인지 검사합니다.
- **src/main/java/com/wanted/sns_feed_service/util/Ut.java**
  - [x]  toStr : Map을 Json 형태로 변환합니다.
  - [x]  toMap : Json을 Map으로 변환합니다.

## 📷 스크린샷

## 👀 기타

- 로그인 방식 등 결정되면 시큐리티 및 매 요청마다 JWT 들고와야 되도록 수정하겠습니다.
- application-db => secret 변경해주시고, 시크릿키는 PR되면 디스코드 채팅방에 남겨둘게요!

