### PR TITLE
[Feat] 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0"
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
     // JWT 라이브러리
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Bcrypt 라이브러리
+    implementation group: 'at.favre.lib', name: 'bcrypt', version: '0.10.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wanted/sns_feed_service/config/SwaggerConfig.java
+++ b/src/main/java/com/wanted/sns_feed_service/config/SwaggerConfig.java
@@ -1,27 +1,26 @@
 package com.wanted.sns_feed_service.config;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.info.Info;
-import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 
 @OpenAPIDefinition(
         info = @Info(title = "sns",
                 description = "sns api - personal project",
                 version = "v1")
 )
-@RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
-    @Bean
-    public GroupedOpenApi snsOpenApi(){
-        String[] paths = {"/v1/**"};
-
-        return GroupedOpenApi.builder()
-                .group("sns")
-                .pathsToMatch(paths)
-                .build();
-    }
+    // @Bean
+    // public GroupedOpenApi snsOpenApi(){
+    //     String[] paths = {"/v1/**"};
+    //
+    //     return GroupedOpenApi.builder()
+    //             .group("sns")
+    //             .pathsToMatch(paths)
+    //             .build();
+    // }
 }

--- a/src/main/java/com/wanted/sns_feed_service/initData/NotProd.java
+++ b/src/main/java/com/wanted/sns_feed_service/initData/NotProd.java
@@ -16,6 +16,7 @@ import com.wanted.sns_feed_service.hashTag.entity.HashTag;
 import com.wanted.sns_feed_service.hashTag.repository.HashTagRepository;
 import com.wanted.sns_feed_service.member.entity.Member;
 import com.wanted.sns_feed_service.member.repository.MemberRepository;
+import com.wanted.sns_feed_service.util.Ut;
 
 @Configuration
 @Profile({"dev", "test"})
@@ -23,8 +24,8 @@ public class NotProd {
 	@Bean
 	CommandLineRunner initData(MemberRepository memberRepository, FeedRepository feedRepository,
 		HashTagRepository hashTagRepository) {
-		// TODO : 암호화 필요
-		String password = "1234";
+
+		String password = Ut.encrypt.encryptPW("1234");
 		return args -> {
 			List<Member> memberList = new ArrayList<>();
 			Member user1 = Member.builder()

--- a/src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.wanted.sns_feed_service.member.entity.Member;
 import com.wanted.sns_feed_service.member.service.MemberService;
 import com.wanted.sns_feed_service.rsData.RsData;
 
@@ -27,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/member", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-@Tag(name = "MemberController", description = "회원가입, 로그인")
+@Tag(name = "MemberController", description = "회원가입, 로그인처리 컨트롤러")
 public class MemberController {
 	private final MemberService memberService;
 

--- a/src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java
@@ -1,0 +1,63 @@
+package com.wanted.sns_feed_service.member.controller;
+
+import static org.springframework.http.MediaType.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.wanted.sns_feed_service.member.entity.Member;
+import com.wanted.sns_feed_service.member.service.MemberService;
+import com.wanted.sns_feed_service.rsData.RsData;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/member", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+@Tag(name = "MemberController", description = "회원가입, 로그인")
+public class MemberController {
+	private final MemberService memberService;
+
+	@Data
+	public static class SignupRequest {
+		@NotBlank(message = "id를 입력해주세요")
+		private String account;
+		@NotBlank(message = "pw를 입력해주세요")
+		@Pattern(regexp = "^(?![0-9]{10,}$)(?!.*(.)\\1{2,}).{10,}$", message = "비밀번호는 10자 이상 입력해야 하며, 숫자로만 이루어 질 수 없으며 3회 이상 연속되는 문자를 사용할 수 없습니다.")
+		private String password;
+		@Email(message = "올바른 이메일 형식을 입력하세요")
+		@NotBlank(message = "이메일을 입력해주세요")
+		private String email;
+	}
+
+	@PostMapping("/signup")
+	@Operation(summary = "회원가입")
+	public RsData signup(@Valid @RequestBody SignupRequest signupRequest, BindingResult bindingResult) {
+		// 요청 객체에서 입력하지 않은 부분이 있다면 메세지를 담아서 RsData 객체 바로 리턴
+		if (bindingResult.hasErrors()) {
+			List<String> errorMessages = bindingResult.getAllErrors()
+				.stream()
+				.map(error -> error.getDefaultMessage())
+				.collect(Collectors.toList());
+			return RsData.of("F-1", errorMessages.get(0));
+		}
+		// 입력 이상 없다면 계정 가입
+		RsData rsData = memberService.join(signupRequest.getAccount(), signupRequest.getPassword(), signupRequest.getEmail());
+
+		return rsData;
+	}
+
+}

--- a/src/main/java/com/wanted/sns_feed_service/member/entity/Member.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/entity/Member.java
@@ -2,10 +2,13 @@ package com.wanted.sns_feed_service.member.entity;
 
 import static jakarta.persistence.GenerationType.*;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +25,9 @@ public class Member {
 	private Long id;
 	@Column(unique = true)
 	private String account;
+	@JsonIgnore
 	private String password;
+	@Email(message = "올바른 이메일 형식을 입력하세요")
 	private String email;
 	private String accessToken;
 }

--- a/src/main/java/com/wanted/sns_feed_service/member/repository/MemberRepository.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/repository/MemberRepository.java
@@ -1,7 +1,10 @@
 package com.wanted.sns_feed_service.member.repository;
 
+import java.util.Optional;
+
 import com.wanted.sns_feed_service.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {
+	Optional<Member> findByAccount(String account);
 }

--- a/src/main/java/com/wanted/sns_feed_service/member/service/MemberService.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/service/MemberService.java
@@ -1,0 +1,41 @@
+package com.wanted.sns_feed_service.member.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.wanted.sns_feed_service.jwt.JwtProvider;
+import com.wanted.sns_feed_service.member.entity.Member;
+import com.wanted.sns_feed_service.member.repository.MemberRepository;
+import com.wanted.sns_feed_service.rsData.RsData;
+import com.wanted.sns_feed_service.util.Ut;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+	private final MemberRepository memberRepository;
+	private final JwtProvider jwtProvider;
+
+	@Transactional
+	public RsData join(String account, String password, String email) {
+		Optional<Member> opMember = memberRepository.findByAccount(account);
+		if(opMember.isPresent()) {
+			return RsData.of("F-1", "이미 가입한 Id가 있습니다.");
+		}
+
+		Member member = Member.builder()
+			.account(account)
+			.password(Ut.encrypt.encryptPW(password))
+			.email(email)
+			.build();
+
+		memberRepository.save(member);
+
+		return RsData.of("S-1", "회원가입 완료, 로그인 후 이용해주세요!");
+	}
+
+}

--- a/src/main/java/com/wanted/sns_feed_service/rsData/RsData.java
+++ b/src/main/java/com/wanted/sns_feed_service/rsData/RsData.java
@@ -1,0 +1,34 @@
+package com.wanted.sns_feed_service.rsData;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RsData<T> {
+	private String resultCode;
+	private String msg;
+	private T data;
+
+	public static <T> RsData<T> of(String resultCode, String msg, T data) {
+		return new RsData<>(resultCode, msg, data);
+	}
+
+	public static <T> RsData<T> of(String resultCode, String msg) {
+		return of(resultCode, msg, null);
+	}
+
+	@JsonIgnore // Json 형태 미포함
+	public boolean isSuccess() {
+		return resultCode.startsWith("S-");
+	}
+
+	@JsonIgnore
+	public boolean isFail() {
+		return !isSuccess();
+	}
+}

--- a/src/main/java/com/wanted/sns_feed_service/util/Ut.java
+++ b/src/main/java/com/wanted/sns_feed_service/util/Ut.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import at.favre.lib.crypto.bcrypt.BCrypt;
+
 public class Ut {
 	public static class json {
 		// map을 Json 형태 변환 매서드
@@ -25,6 +27,17 @@ public class Ut {
 			} catch (JsonProcessingException e) {
 				return null;
 			}
+		}
+	}
+
+	public static class encrypt {
+		public static String encryptPW(String password) {
+			return BCrypt.withDefaults().hashToString(12, password.toCharArray());
+		}
+
+		public static BCrypt.Result verifyPW(String plainPassword ,String encryptPassword) {
+			BCrypt.Result result = BCrypt.verifyer().verify(plainPassword.toCharArray(), encryptPassword);
+			return result; // result.verified == true
 		}
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,3 @@ logging:
     com.wanted.sns_feed_service: DEBUG  #패키지명
     org.hibernate.orm.jdbc.bind: TRACE # SQL 완벽하게 나오게(?에 매칭된 숫자 출력)
     org.hibernate.orm.jdbc.extract: TRACE #쿼리의 결과도 출력됨
-
-custom:
-  jwt:
-    secretKey:

--- a/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
@@ -1,0 +1,103 @@
+package com.wanted.sns_feed_service.member.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class MemberControllerTests {
+	@Autowired
+	private MockMvc mvc;
+
+	@Test
+	@DisplayName("POST /member/signup 은 회원가입을 처리한다.")
+	void t1() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				post("/member/signup")
+					.content("""
+						{
+						    "account": "puar12",
+						    "password": "cjfgus2514",
+						    "email": "aaaaa@naver.com"
+						}
+						""".stripIndent())
+					// JSON 형태로 보내겠다
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("회원가입 완료, 로그인 후 이용해주세요!"));
+	}
+
+	@Test
+	@DisplayName("회원가입 시 이메일을 입력하지 않으면 가입이 되지 않는다.")
+	void t2() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				post("/member/signup")
+					.content("""
+						{
+						    "account": "puar12",
+						    "password": "cjfgus2514",
+						    "email": ""
+						}
+						""".stripIndent())
+					// JSON 형태로 보내겠다
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("F-1"))
+			.andExpect(jsonPath("$.msg").value("이메일을 입력해주세요"));
+	}
+
+	@Test
+	@DisplayName("회원가입 시 비밀번호 제약조건을 지키지 않으면 가입이 되지 않는다.")
+	void t3() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				post("/member/signup")
+					.content("""
+						{
+						    "account": "puar12",
+						    "password": "1234",
+						    "email": "aaaaa@naver.com"
+						}
+						""".stripIndent())
+					// JSON 형태로 보내겠다
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("F-1"))
+			.andExpect(jsonPath("$.msg").value("비밀번호는 10자 이상 입력해야 하며, 숫자로만 이루어 질 수 없으며 3회 이상 연속되는 문자를 사용할 수 없습니다."));
+	}
+}


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#] 

close #10 
### 📑 개요

- 회원 가입 기능을 구현하였습니다.
- 이메일 검증을 구현했구여, @Email의 경우 null값이나 빈값은 검증을 안하기 때문에 @NotBlank를 추가로 활용하였습니다.
- 비밀번호 제약 조건을 3가지로 설정했습니다.
  - 10자 이상 입력
  - 숫자로만 이루어 질 수 없음
  - 연속된 문자 3개 이상 작성 불가
 
###  🧷 변경사항

- **build.gradle**
  - [x] spring Doc 최신 버전으로 변경하였습니다.
  - [x] 비밀번호 암호화에 필요한 bcrypt 의존성 추가
    - [공식문서](https://github.com/patrickfav/bcrypt)
- **src/main/java/com/wanted/sns_feed_service/config/SwaggerConfig.java**
  - [x] Swagger 적용되게 불필요 코드 주석 처리
    - 저는 저 밑에 내용 아에 안쓰면서 해서 밑에 내용 주석 처리 하니 Swagger 문서에 API가 잡히더라구요. 저거 주석 풀면 안잡힙니다. 혹시 필요하신가요? 저는 없이 써가지고

- **src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java**
  - [x] SignupRequest : DTO 객체로 비밀번호 검증 및 이메일 검증 등 사용자 입력을 검증합니다.
  - [x]  signup : SignupRequest 요청으로 받은 내용을 Valid 해서 bindingResult 객체에 담긴 바로 입구컷 당하는 오류 메세지가 있다면 바로 회원 가입 실패를 반환합니다.
- **src/main/java/com/wanted/sns_feed_service/member/entity/Member.java**
  - [x] 사용자 정보를 반환할 때 PW가 JSON화 되지 않도록 수정하였습니다.

- **src/main/java/com/wanted/sns_feed_service/member/service/MemberService.java**
  - [x] join : Id로 가입된 데이터를 찾고 있다면 회원 가입 실패 메세지를 전달합니다.
    - 비밀번호 암호화를 통해 DB에 저장합니다.
    - 회원가입 성공 시 로그인 후 이용하라는 메시지와 함께 전송됩니다.


- **src/main/java/com/wanted/sns_feed_service/rsData/RsData.java**
  - `RsData로 응답 코드, 메세지, 데이터를 담고 있습니다.`
  - RsData.of("응답 코드", "메세지", 데이터) 를 하면 데이터를 같이 넘길 수 있습니다.
  - RsData.of("응답 코드", "메세지")를 하면 메세지까지만 넘길 수 있습니다.
  - 객체로 반환하면 메세지 컨버터(스프링부트 현재 잭슨 라이브러리)에 의해 JSON화가 자동으로 됩니다!
  - data 부분에 객체를 넘기면 Json화 되어 data : {"id" : "3", "name" : "good"} 형태로 추가됩니다!
  - 원래는 응답 코드를 고유하게 설정해서 다 수정하기는 해야합니다!
  - 성공 코드는 항상 200번대가 나오고, 프론트 단에서 통일된 메세지 규격을 지키면서 넘기기에 좋을 것 같아요. 물론 상태 번호도 있으면 좋겠지만 저는 이런 방식으로 활용합니다!
![image](https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/126079049/13afceab-aa48-474f-b438-f5860c27c4c1)


- **src/main/java/com/wanted/sns_feed_service/util/Ut.java**
  - 암호화 메서드를 구현하였습니다.
  - 이제 암호화 시 `Ut.encrypt.encryptPW(String password)` 하면 암호화 되고
  - 비밀번호 확인 시  `Ut.encrypt.verifyPW(원문 비번 , 객체(DB)에서 가져온 PW)`를 하면 비교할 수 있습니다.

## 📷 스크린샷
![image](https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/126079049/2907439f-6925-4c28-a27e-c6c9ea58099a)
- swagger @Bean 부분을 주석처리 해야 나옵니다..!

## 👀 기타
- SignupRequest(DTO) 객체로 입력 받을때만 검증했는데, **보안 강화를 위해 컨트롤러나 서비스단에서 한번 더 검증**을 하는것도 좋을까요? 의견 주시면 감사하겠습니다 😄 
- **이메일 발송, 코드는 새로 이슈 파서 구현할게요!**