### PR TITLE
[Feat] 피드 목록 및 피드 검색 구현

### DIFF
--- a/src/main/java/com/wanted/sns_feed_service/config/QueryDslConfig.java
+++ b/src/main/java/com/wanted/sns_feed_service/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.wanted.sns_feed_service.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(this.em);
+    }
+
+}

--- a/src/main/java/com/wanted/sns_feed_service/feed/FeedService.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/FeedService.java
@@ -1,0 +1,27 @@
+package com.wanted.sns_feed_service.feed;
+
+import com.wanted.sns_feed_service.feed.entity.Type;
+import com.wanted.sns_feed_service.feed.entity.dto.FeedResponseDto;
+import com.wanted.sns_feed_service.feed.repository.FeedRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FeedService {
+
+    private final FeedRepository feedRepository;
+
+    /**
+     * 검색 필터링
+     */
+    public Page<FeedResponseDto> search(String hashtag, Type type, String searchBy, String orderBy, String orderTarget, String searchKeyword, Pageable pageable) {
+        // TODO hashtag      미 입력시 본인 계정
+
+        return feedRepository.filter(hashtag, type, searchBy, orderBy, orderTarget, searchKeyword, pageable);
+    }
+}

--- a/src/main/java/com/wanted/sns_feed_service/feed/controller/FeedController.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/controller/FeedController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("v1/feed")
-@Tag(name = "MemberController", description = "회원가입, 로그인처리 컨트롤러")
+@Tag(name = "FeedController", description = "피드 컨트롤러")
 public class FeedController {
 
     private final FeedService feedService;

--- a/src/main/java/com/wanted/sns_feed_service/feed/controller/FeedController.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/controller/FeedController.java
@@ -1,0 +1,57 @@
+package com.wanted.sns_feed_service.feed.controller;
+
+import com.wanted.sns_feed_service.feed.FeedService;
+import com.wanted.sns_feed_service.feed.entity.Type;
+import com.wanted.sns_feed_service.response.ResResult;
+import com.wanted.sns_feed_service.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("v1/feed")
+@Tag(name = "MemberController", description = "회원가입, 로그인처리 컨트롤러")
+public class FeedController {
+
+    private final FeedService feedService;
+
+    /**
+     * 피드 검색
+     */
+    @GetMapping("")
+    @Operation(summary = "피드 목록", description = "조건에 따른 피드 검색을 하고, 피드 목록을 불러 옵니다.")
+    public ResponseEntity<ResResult> search(
+            @RequestParam(value = "hashtag", required = false) String hashtag, // 정확히 일치하는 값 조회, 미 입력시 본인 계정
+            @RequestParam(value = "type", required = false) Type type, // 미입력 시 모든 type 조회
+            @RequestParam(value = "order_by", required = false, defaultValue = "DESC") String orderBy, // desc, asc
+            @RequestParam(value = "order_target", required = false, defaultValue = "created_at") String orderTarget, // 정렬 기준이며, created_at,updated_at,like_count,share_count,view_count 가 사용 가능, 오름차순 , 내림차순 모두 가능
+            @RequestParam(value = "search_by", required = false) String searchBy, // 검색 기준이며, title , content, title,content 이 사용, 미입력 시  title,content
+            @RequestParam(value = "search", required = false) String searchKeyword, // 검색할 키워드 title 또는 content 또는 title + content 검색
+            @RequestParam(value = "page", defaultValue = "0") int pageNumber, // 조회하려는 페이지
+            @RequestParam(value = "page_count", defaultValue = "10") int pageSize // 페이지 당 게시물 갯수
+            //TODO : username 받기
+    ) {
+
+        ResponseCode feedSearchCode = ResponseCode.FEED_SEARCH;
+
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+
+        return ResponseEntity.ok(
+                ResResult.builder()
+                        .responseCode(feedSearchCode)
+                        .code(feedSearchCode.getCode())
+                        .message(feedSearchCode.getMessage())
+                        .data(feedService.search(hashtag, type, searchBy, orderBy, orderTarget, searchKeyword, pageable))
+                        .build()
+
+        );
+    }
+}

--- a/src/main/java/com/wanted/sns_feed_service/feed/entity/dto/FeedRequestDto.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/entity/dto/FeedRequestDto.java
@@ -1,0 +1,21 @@
+package com.wanted.sns_feed_service.feed.entity.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wanted.sns_feed_service.feed.entity.Type;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FeedRequestDto {
+
+    private Long id;
+    private String contentId;
+    private Type type;
+    private String title;
+    private String content;
+    private int viewCount;
+    private int likeCount;
+    private int shareCount;
+}

--- a/src/main/java/com/wanted/sns_feed_service/feed/entity/dto/FeedResponseDto.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/entity/dto/FeedResponseDto.java
@@ -1,0 +1,59 @@
+package com.wanted.sns_feed_service.feed.entity.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wanted.sns_feed_service.feed.entity.Feed;
+import com.wanted.sns_feed_service.feed.entity.Type;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FeedResponseDto {
+
+    private Long id;
+    private String contentId;
+    private Type type;
+    private String title;
+    private String content;
+    private int viewCount;
+    private int likeCount;
+    private int shareCount;
+
+    public static FeedResponseDto of(Feed feed) {
+        return FeedResponseDto.builder()
+                .contentId(feed.getContentId())
+                .type(feed.getType())
+                .title(feed.getTitle())
+                .content(feed.getContent())
+                .viewCount(feed.getViewCount())
+                .likeCount(feed.getLikeCount())
+                .shareCount(feed.getShareCount())
+                .build();
+    }
+
+    public static List<FeedResponseDto> of(List<Feed> feedList) {
+
+        List<FeedResponseDto> feedResponseDtoList = new ArrayList<>();
+
+        for (Feed feed : feedList) {
+            String content = feed.getContent();
+            String newContent = content.length() > 20 ? feed.getContent().substring(0, 20) + "..." : content;
+
+            feedResponseDtoList.add(FeedResponseDto.builder()
+                    .contentId(feed.getContentId())
+                    .type(feed.getType())
+                    .title(feed.getTitle())
+                    .content(newContent)
+                    .viewCount(feed.getViewCount())
+                    .likeCount(feed.getLikeCount())
+                    .shareCount(feed.getShareCount())
+                    .build()
+            );
+        }
+        return feedResponseDtoList;
+    }
+}

--- a/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepository.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepository.java
@@ -3,5 +3,5 @@ package com.wanted.sns_feed_service.feed.repository;
 import com.wanted.sns_feed_service.feed.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FeedRepository extends JpaRepository<Feed,Long> {
+public interface FeedRepository extends JpaRepository<Feed,Long>, FeedRepositoryCustom{
 }

--- a/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.wanted.sns_feed_service.feed.repository;
+
+import com.wanted.sns_feed_service.feed.entity.Type;
+import com.wanted.sns_feed_service.feed.entity.dto.FeedResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FeedRepositoryCustom {
+
+    Page<FeedResponseDto> filter(String hashtag,
+                                 Type type,
+                                 String searchBy,
+                                 String order,
+                                 String orderTarget,
+                                 String searchKeyword,
+                                 Pageable pageable);
+}

--- a/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepositoryImpl.java
@@ -62,15 +62,19 @@ public class FeedRepositoryImpl extends Querydsl4RepositorySupport implements Fe
             return null; // 검색 키워드가 없을 때 필터링하지 않음
         }
 
+        if (searchBy == null) {
+            // searchBy가 null인 경우, 디폴트로 타이틀 + 내용 전체 검색
+            return feed.title.containsIgnoreCase(searchKeyword).or(feed.content.containsIgnoreCase(searchKeyword));
+        }
+
         switch (searchBy) {
             case "title": // 타이틀 검색
                 return feed.title.containsIgnoreCase(searchKeyword);
             case "content": // 내용 검색
                 return feed.content.containsIgnoreCase(searchKeyword);
-            default: // 이외의 경우는 타이틀 + 내용 전체 검색
-                return feed.title.containsIgnoreCase(searchKeyword).or(feed.content.containsIgnoreCase(searchKeyword));
         }
-
+        // 이외의 경우는 타이틀 + 내용 전체 검색
+        return feed.title.containsIgnoreCase(searchKeyword).or(feed.content.containsIgnoreCase(searchKeyword));
     }
 
     /**

--- a/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepositoryImpl.java
@@ -1,0 +1,116 @@
+package com.wanted.sns_feed_service.feed.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.wanted.sns_feed_service.feed.entity.Feed;
+import com.wanted.sns_feed_service.feed.entity.Type;
+import com.wanted.sns_feed_service.feed.entity.dto.FeedResponseDto;
+import com.wanted.sns_feed_service.feed.repository.support.Querydsl4RepositorySupport;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.wanted.sns_feed_service.feed.entity.QFeed.feed;
+
+public class FeedRepositoryImpl extends Querydsl4RepositorySupport implements FeedRepositoryCustom {
+    public FeedRepositoryImpl() {
+        super(Feed.class);
+    }
+
+    /**
+     * 검색 필터
+     */
+    @Override
+    public Page<FeedResponseDto> filter(String hashtag, // hashtag
+                                        Type type, // feed type
+                                        String searchBy, // 검색 기준 (제목, 내용, 제목 + 내용)
+                                        String orderBy,// 정렬 순서 (DESC, ASC)
+                                        String orderTarget,// 정렬 기준 (등록 일시, count 순서 등 )
+                                        String searchKeyword,// 검색어
+                                        Pageable pageable) { // 페이지 정보
+
+        JPAQuery<Feed> feedJPAQuery = selectFrom(feed)
+                .where(
+                        hashtagFilter(hashtag),
+                        typeFilter(type),
+                        searchFilter(searchBy, searchKeyword)
+                );
+
+        List<FeedResponseDto> feedList = FeedResponseDto.of(feedJPAQuery
+                .orderBy(orderByFilter(Order.valueOf(orderBy.toUpperCase()), orderTarget))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch());
+
+        // for data count
+        long count = feedJPAQuery.fetchCount();
+
+        return new PageImpl<>(feedList, pageable, count);
+
+    }
+
+    /**
+     * 키워드 검색
+     */
+    private BooleanExpression searchFilter(String searchBy, String searchKeyword) {
+
+        if (searchKeyword == null || searchKeyword.isEmpty()) {
+            return null; // 검색 키워드가 없을 때 필터링하지 않음
+        }
+
+        switch (searchBy) {
+            case "title": // 타이틀 검색
+                return feed.title.containsIgnoreCase(searchKeyword);
+            case "content": // 내용 검색
+                return feed.content.containsIgnoreCase(searchKeyword);
+            default: // 이외의 경우는 타이틀 + 내용 전체 검색
+                return feed.title.containsIgnoreCase(searchKeyword).or(feed.content.containsIgnoreCase(searchKeyword));
+        }
+
+    }
+
+    /**
+     * 정렬
+     * - created_at,updated_at,like_count,share_count,view_count 사용 가능
+     * - 오름차순 , 내림차순 가능
+     */
+    private OrderSpecifier<?> orderByFilter(Order orderBy, String orderTarget) {
+
+        switch (orderTarget) {
+            case "created_at":
+                return new OrderSpecifier<>(orderBy, feed.createdAt);
+            case "updated_at":
+                return new OrderSpecifier<>(orderBy, feed.updatedAt);
+            case "like_count":
+                return new OrderSpecifier<>(orderBy, feed.likeCount);
+            case "share_count":
+                return new OrderSpecifier<>(orderBy, feed.shareCount);
+            case "view_count":
+                return new OrderSpecifier<>(orderBy, feed.viewCount);
+        }
+        return new OrderSpecifier<>(orderBy, feed.createdAt); // 정렬 미입력 시 최신 생성 순
+    }
+
+
+    /**
+     * hashtag 조회
+     */
+    private BooleanExpression hashtagFilter(String hashtag) {
+        if (hashtag == null || hashtag.isEmpty()) {
+            return feed.hashTags.any().isNotNull(); // TODO : null 이면 자신의 계정 반환하게 하기, 현재는 모든 목록 불러오게 함.
+        }
+        return feed.hashTags.any().name.eq(hashtag);
+    }
+
+    /**
+     * type 조회
+     */
+    private BooleanExpression typeFilter(Type type) {
+        return type != null ? feed.type.eq(type) : null;
+    }
+
+}

--- a/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/repository/FeedRepositoryImpl.java
@@ -62,7 +62,7 @@ public class FeedRepositoryImpl extends Querydsl4RepositorySupport implements Fe
             return null; // 검색 키워드가 없을 때 필터링하지 않음
         }
 
-        if (searchBy == null) {
+        if (searchBy == null || searchBy.equals("title_content")) {
             // searchBy가 null인 경우, 디폴트로 타이틀 + 내용 전체 검색
             return feed.title.containsIgnoreCase(searchKeyword).or(feed.content.containsIgnoreCase(searchKeyword));
         }

--- a/src/main/java/com/wanted/sns_feed_service/feed/repository/support/Querydsl4RepositorySupport.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/repository/support/Querydsl4RepositorySupport.java
@@ -1,0 +1,105 @@
+package com.wanted.sns_feed_service.feed.repository.support;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
+import org.springframework.data.jpa.repository.support.Querydsl;
+import org.springframework.data.querydsl.SimpleEntityPathResolver;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
+
+import java.util.List;
+import java.util.function.Function;
+
+@Repository
+public abstract class Querydsl4RepositorySupport {
+
+    private final Class domainClass;
+    private Querydsl querydsl;
+    private EntityManager entityManager;
+    private JPAQueryFactory queryFactory;
+
+    public Querydsl4RepositorySupport(Class<?> domainClass) {
+        Assert.notNull(domainClass, "Domain class must not be null!");
+        this.domainClass = domainClass;
+    }
+
+    @Autowired
+    public void setEntityManager(EntityManager entityManager) {
+        Assert.notNull(entityManager, "EntityManager must not be null!");
+
+        JpaEntityInformation entityInformation =
+                JpaEntityInformationSupport.getEntityInformation(domainClass, entityManager);
+
+        SimpleEntityPathResolver resolver = SimpleEntityPathResolver.INSTANCE;
+        EntityPath path = resolver.createPath(entityInformation.getJavaType());
+        this.entityManager = entityManager;
+        this.querydsl = new Querydsl(entityManager, new
+                PathBuilder<>(path.getType(), path.getMetadata()));
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @PostConstruct
+    public void validate() {
+        Assert.notNull(entityManager, "EntityManager must not be null!");
+        Assert.notNull(querydsl, "Querydsl must not be null!");
+        Assert.notNull(queryFactory, "QueryFactory must not be null!");
+    }
+
+    protected JPAQueryFactory getQueryFactory() {
+        return queryFactory;
+    }
+
+    protected Querydsl getQuerydsl() {
+        return querydsl;
+    }
+
+    protected EntityManager getEntityManager() {
+        return entityManager;
+    }
+
+    protected <T> JPAQuery<T> select(Expression<T> expr) {
+        return getQueryFactory().select(expr);
+    }
+
+    protected <T> JPAQuery<T> selectFrom(EntityPath<T> from) {
+        return getQueryFactory().selectFrom(from);
+    }
+
+    protected <T> Page<T> applyPagination(Pageable pageable,
+                                          Function<JPAQueryFactory, JPAQuery> contentQuery) {
+
+        JPAQuery jpaQuery = contentQuery.apply(getQueryFactory());
+
+        List<T> content = getQuerydsl().applyPagination(pageable,
+                jpaQuery).fetch();
+
+        return PageableExecutionUtils.getPage(content, pageable,
+                jpaQuery::fetchCount);
+    }
+
+    protected <T> Page<T> applyPagination(Pageable pageable,
+                                          Function<JPAQueryFactory, JPAQuery> contentQuery, Function<JPAQueryFactory,
+            JPAQuery> countQuery) {
+
+        JPAQuery jpaContentQuery = contentQuery.apply(getQueryFactory());
+
+        List<T> content = getQuerydsl().applyPagination(pageable,
+                jpaContentQuery).fetch();
+
+        JPAQuery countResult = countQuery.apply(getQueryFactory());
+
+        return PageableExecutionUtils.getPage(content, pageable,
+                countResult::fetchCount);
+    }
+}

--- a/src/main/java/com/wanted/sns_feed_service/response/ResResult.java
+++ b/src/main/java/com/wanted/sns_feed_service/response/ResResult.java
@@ -1,0 +1,29 @@
+package com.wanted.sns_feed_service.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 공통적으로 반환 될 속성
+ */
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResResult<T> {
+
+    ResponseCode responseCode;
+    String code;
+    String message;
+    T data;
+
+    @Override
+    public String toString() {
+        return "ResResult{" +
+                "responseCode=" + responseCode +
+                ", code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                ", data=" + data +
+                '}';
+    }
+}

--- a/src/main/java/com/wanted/sns_feed_service/response/ResponseCode.java
+++ b/src/main/java/com/wanted/sns_feed_service/response/ResponseCode.java
@@ -1,0 +1,33 @@
+package com.wanted.sns_feed_service.response;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@ToString
+public enum ResponseCode {
+
+    // FEED
+    FEED_SEARCH(HttpStatus.CREATED, "200", "피드 조회 성공");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ResponseCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    public ResponseEntity<ResResult> toResponse(Object data) {
+        return new ResponseEntity<>(ResResult.builder()
+                .responseCode(this)
+                .code(this.code)
+                .message(this.message)
+                .data(data)
+                .build(), httpStatus.OK);
+    }
+}

--- a/src/test/java/com/wanted/sns_feed_service/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/wanted/sns_feed_service/feed/controller/FeedControllerTest.java
@@ -5,6 +5,7 @@ import com.wanted.sns_feed_service.feed.repository.FeedRepository;
 import com.wanted.sns_feed_service.hashTag.entity.HashTag;
 import com.wanted.sns_feed_service.hashTag.repository.HashTagRepository;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,10 +18,12 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import static com.wanted.sns_feed_service.feed.entity.Type.INSTAGRAM;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Slf4j
 class FeedControllerTest {
 
     @Autowired
@@ -29,6 +32,7 @@ class FeedControllerTest {
     FeedRepository feedRepository;
     @Autowired
     HashTagRepository hashTagRepository;
+
     @DisplayName("해시 테그 검색 테스트, hashtag 가 정확하게 일치하지 않으면 데이터가 0건")
     @Test
     void 해시_테그_검색_실패() throws Exception {
@@ -38,7 +42,7 @@ class FeedControllerTest {
                         .param("hashtag", "테스트")
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(0))
+                .andExpect(jsonPath("$.data.content.size()").value(0))
                 .andDo(print());
     }
 
@@ -51,7 +55,7 @@ class FeedControllerTest {
                         .param("hashtag", "테스트태그1")
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(10))
+                .andExpect(jsonPath("$.data.content.size()").value(10))
                 .andDo(print());
     }
 
@@ -64,7 +68,8 @@ class FeedControllerTest {
                         .param("type", "INSTAGRAM")
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(10))
+                .andExpect(jsonPath("$.data.content.size()").value(10))
+                .andExpect(jsonPath("$.data.content[0].type").value("INSTAGRAM"))
                 .andDo(print());
     }
 
@@ -78,7 +83,7 @@ class FeedControllerTest {
                         .param("order_type", "created_at")
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].contentId").value("threads9"))
+                .andExpect(jsonPath("$.data.content[0].content").value("쓰레드 테스트 피드9"))
                 .andDo(print());
     }
 
@@ -92,7 +97,7 @@ class FeedControllerTest {
                         .param("order_type", "created_at")
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].contentId").value("instagram0"))
+                .andExpect(jsonPath("$.data.content[0].content").value("인스타 테스트 피드0"))
                 .andDo(print());
     }
 
@@ -102,11 +107,11 @@ class FeedControllerTest {
 
         //when, then
         mockMvc.perform(get("/v1/feed")
-                        .param("search_by", "title") // 가장 오래전에 생성한 피드가 가장 위에 오게 됨.
+                        .param("search_by", "title") // title 로 검색
                         .param("search", "9")
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(4)) // title 에 9가 들어간건 4개 뿐임
+                .andExpect(jsonPath("$.data.content.size()").value(4)) // title 에 9가 들어간건 4개 뿐임
                 .andDo(print());
     }
 
@@ -139,25 +144,84 @@ class FeedControllerTest {
                         .param("search", "꿔바로우")
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(2))
+                .andExpect(jsonPath("$.data.content.size()").value(2))
                 .andDo(print());
     }
 
-    @DisplayName("검색 테스트")
+    @DisplayName("글자수 20자 제한 테스트")
     @Test
-    void 검색_테스트() throws Exception {
+    @Transactional
+    void 글자수_20자_제한_테스트() throws Exception {
+
+        // given
+
+        // 태그 추가
+        HashTag tag = HashTag.builder()
+                .name("타짜")
+                .build();
+        hashTagRepository.save(tag);
+
+        // 피드 추가
+        String longContent = "싸늘하다. 가슴에 비수가 날아와 꽂힌다. 하지만 걱정하지 마라. 손은 눈보다 빠르니까.";
+        String shortContent = "묻고 더블로 가!";
+
+        Feed insta1 = Feed.builder().contentId("타짜1").type(INSTAGRAM).title("타짜")
+                .content(longContent).build();
+
+        Feed insta2 = Feed.builder().contentId("타짜2").type(INSTAGRAM).title("타짜")
+                .content(shortContent).build();
+
+        insta1.addTag(tag);
+        insta2.addTag(tag);
+
+        feedRepository.save(insta1);
+        feedRepository.save(insta2);
+
+        // when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("hashtag", "타짜") // tag 로 검색
+                        .param("order_target","create_at") // 생성순
+                        .param("order_by","asc") // 먼저 생성된 데이터가 가장 상단에 위치
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].content") // 목록의 첫번째 content 를 가져옴
+                        .value(longContent.substring(0, 20) + "...")) // 글자 수가 20을 넘어가면 이후 글자는 생략됨.
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].content")
+                        .value(shortContent)) // 글자 수가 20을 넘어가지 않을 때는 생략 없음.
+                .andDo(print());
+    }
+
+    @DisplayName("통합 검색 테스트")
+    @Test
+    void 통합_검색_테스트() throws Exception {
 
         //when, then
         mockMvc.perform(get("/v1/feed")
-                        .param("hashtag", "테스트태그3")
-                        .param("search", "9")
-                        .param("order_by","desc")
-                        .param("page_count","1")
+                        .param("hashtag", "테스트태그3") // 해시테그로 검색
+                        .param("search", "9") // 검색어
+                        .param("order_by", "desc") // 정렬 순서
+                        .param("page_count", "1") // 하나의 page 에 담길 데이터 수
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.totalElements").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.totalPages").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].contentId").value("threads9"))
+                .andExpect(jsonPath("$.data.totalElements").value(2)) // 총 검색된 데이터 건 수
+                .andExpect(jsonPath("$.data.totalPages").value(2)) // 총 페이지 수
+                .andExpect(jsonPath("$.data.content[0].content").value("쓰레드 테스트 피드9"))
+                .andDo(print());
+    }
+
+    @DisplayName("통합 검색 테스트2")
+    @Test
+    void 통합_검색_테스트2() throws Exception {
+
+        //when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("type", "INSTAGRAM") // 타입으로 검색
+                        .param("search_by", "title") // 타이틀로 검색
+                        .param("search", "틀0") // 검색어
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1)) // 총 검색된 데이터 건 수
+                .andExpect(jsonPath("$.data.content[0].title").value("인스타 테스트 타이틀0"))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/wanted/sns_feed_service/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/wanted/sns_feed_service/feed/controller/FeedControllerTest.java
@@ -1,0 +1,163 @@
+package com.wanted.sns_feed_service.feed.controller;
+
+import com.wanted.sns_feed_service.feed.entity.Feed;
+import com.wanted.sns_feed_service.feed.repository.FeedRepository;
+import com.wanted.sns_feed_service.hashTag.entity.HashTag;
+import com.wanted.sns_feed_service.hashTag.repository.HashTagRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static com.wanted.sns_feed_service.feed.entity.Type.INSTAGRAM;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FeedControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    FeedRepository feedRepository;
+    @Autowired
+    HashTagRepository hashTagRepository;
+    @DisplayName("해시 테그 검색 테스트, hashtag 가 정확하게 일치하지 않으면 데이터가 0건")
+    @Test
+    void 해시_테그_검색_실패() throws Exception {
+
+        //when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("hashtag", "테스트")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(0))
+                .andDo(print());
+    }
+
+    @DisplayName("해시 테그 검색 테스트")
+    @Test
+    void 해시_테그_검색() throws Exception {
+
+        //when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("hashtag", "테스트태그1")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(10))
+                .andDo(print());
+    }
+
+    @DisplayName("타입_검색 테스트")
+    @Test
+    void 타입_검색() throws Exception {
+
+        //when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("type", "INSTAGRAM")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(10))
+                .andDo(print());
+    }
+
+    @DisplayName("정렬 테스트 - created_at, 내림차순 ")
+    @Test
+    void 정렬_테스트1() throws Exception {
+
+        //when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("order_by", "DESC") // 가장 최근에 생성한 피드가 가장 위에 오게 됨.
+                        .param("order_type", "created_at")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].contentId").value("threads9"))
+                .andDo(print());
+    }
+
+    @DisplayName("정렬 테스트 - created_at, 오름차순 ")
+    @Test
+    void 정렬_테스트2() throws Exception {
+
+        //when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("order_by", "asc") // 가장 오래전에 생성한 피드가 가장 위에 오게 됨.
+                        .param("order_type", "created_at")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].contentId").value("instagram0"))
+                .andDo(print());
+    }
+
+    @DisplayName("검색어 테스트")
+    @Test
+    void 검색어_테스트() throws Exception {
+
+        //when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("search_by", "title") // 가장 오래전에 생성한 피드가 가장 위에 오게 됨.
+                        .param("search", "9")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(4)) // title 에 9가 들어간건 4개 뿐임
+                .andDo(print());
+    }
+
+
+    @DisplayName("검색어 테스트 - search_by 를 생략하면 title + content 으로 검색")
+    @Test
+    @Transactional
+    void 검색어_테스트2() throws Exception {
+
+        // given
+
+        // 태그 추가
+        HashTag tag = HashTag.builder()
+                .name("instagram")
+                .build();
+        hashTagRepository.save(tag);
+
+        // 피드 추가
+        Feed insta1 = Feed.builder().contentId("instagram100").type(INSTAGRAM).title("맛있는").content("꿔바로우").build();
+        Feed insta2 = Feed.builder().contentId("instagram200").type(INSTAGRAM).title("꿔바로우").content("좋아하세요?").build();
+
+        insta1.addTag(tag);
+        insta2.addTag(tag);
+
+        feedRepository.save(insta1);
+        feedRepository.save(insta2);
+
+        //when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("search", "꿔바로우")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.size()").value(2))
+                .andDo(print());
+    }
+
+    @DisplayName("검색 테스트")
+    @Test
+    void 검색_테스트() throws Exception {
+
+        //when, then
+        mockMvc.perform(get("/v1/feed")
+                        .param("hashtag", "테스트태그3")
+                        .param("search", "9")
+                        .param("order_by","desc")
+                        .param("page_count","1")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.totalElements").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.totalPages").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].contentId").value("threads9"))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
### 📑 개요
- 게시물 목록을 구현했습니다.
###  🧷 변경사항
- close #15
- 8fa29975cf6f5e8a435deb6c219f2e07357df79c 검색을 구현하기 위해 querydsl 세팅
- 56b5d5e1f963d22251b79f13d1e434bfb6d3282e 피드 전체 목록 불러오기 및 검색 구현
- 1015ee859ed1d04e1f52f521c049f59f27605f69 피드 검색 test
## 📷 스크린샷
- 40ed48c011ab525293306f795db065d3c64e4b04 json 응답 형태
<img width="215" alt="image" src="https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/108582847/b6b5d2a2-bce3-4def-ad67-6d1bc3e08232">

- 56b5d5e1f963d22251b79f13d1e434bfb6d3282e 피드 전체 목록 불러오기 및 검색 구현
<html>
<body>
<!--StartFragment--><ul>
<li>
<p>쿼리 파라미터</p>


query | 속성 | default(미입력 시 값) | 설명
-- | -- | -- | --
hashtag | string |  | 1건의 해시태그, 정확히 일치하는 값만 검색
type | string | 모든 type | type 필드 값 별로 조회.
order_by | string | desc | 오름차순 , 내림차순 가능
order_target | string | created_at | 정렬 기준이며, created_at,updated_at,like_count,share_count,view_count 가 사용 가능
search_by | string | title,content | 검색 기준이며, title , content, title,content 이 사용 가능
search | string |   | search_by 에서 검색할 키워드 이며 유저가 입력합니다. 해당 문자가 포함된 게시물을 검색합니다.
page_count | number | 10 | 페이지당 게시물 갯수
page | number | 0 | 조회하려는 페이지


</li>
</ul>
<!-- notionvc: 95ee4c1d-9d15-4703-a1f5-046e48c1eb65 --><!--EndFragment-->
</body>
</html>


## 👀 기타
- 코드 병합 시 충돌이 일어날 것 같습니당.. ㅠㅠ 
- hashtag 미입력시 본인 계정이 조회 된다는 요구사항은 아직 구현 전입니다.
- 기존 요구사항의 order_by를 오름차순, 내림차순 구현을 위해 order_by와 order_target 으로 나누었습니다.
다른 좋은 아이디어 있으면 언제든 환영입니당!