### PR TITLE
[Feat] 회원가입시 email 인증코드 발송 + 로그인 시 JWT 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     // Bcrypt 라이브러리
     implementation group: 'at.favre.lib', name: 'bcrypt', version: '0.10.2'
+
+    // java-mail-sender
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/generated/com/wanted/sns_feed_service/member/entity/QMember.java
+++ b/src/main/generated/com/wanted/sns_feed_service/member/entity/QMember.java
@@ -29,6 +29,8 @@ public class QMember extends EntityPathBase<Member> {
 
     public final StringPath password = createString("password");
 
+    public final NumberPath<Integer> tempCode = createNumber("tempCode", Integer.class);
+
     public QMember(String variable) {
         super(Member.class, forVariable(variable));
     }

--- a/src/main/java/com/wanted/sns_feed_service/SnsFeedServiceApplication.java
+++ b/src/main/java/com/wanted/sns_feed_service/SnsFeedServiceApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync // 비동기 기능 활성화
 public class SnsFeedServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/wanted/sns_feed_service/config/AsyncConfig.java
+++ b/src/main/java/com/wanted/sns_feed_service/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.wanted.sns_feed_service.config;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+	// core 사이즈 만큼 일 처리
+	// 기본 스레드가 처리할 수 있는 작업량 넘어설 경우 큐에서 대기
+	// 큐의 크기가 넘친다면 MaxSize 만큼 스레드 추가 생성
+	// 5개로 작업 -> 20개인 큐에서 대기 -> 넘침 -> 30개로 늘림
+	// 큐에서 요청이 넘긴다면 RejectExecutionException 발생 -> CallerRunsPolicy 처리
+	// 요청한 Caller Thread에서 직접 처리
+
+	@Bean(name = "taskExecutor1")
+	public ThreadPoolTaskExecutor executor() {
+		ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+		taskExecutor.setCorePoolSize(5);  // 스레드 풀에 속한 기본 스레드 개수
+		taskExecutor.setQueueCapacity(20);  // 이벤트 대기 큐 크기
+		taskExecutor.setMaxPoolSize(30); // 최대 스레드 개수
+		taskExecutor.setThreadNamePrefix("Executor-");
+		taskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+		taskExecutor.setWaitForTasksToCompleteOnShutdown(true); // shutdown시 queue에 남아있는 모든 작업이 완료된 후 shutdown!
+		taskExecutor.setAwaitTerminationSeconds(60);	// shutdown 최대 60초 대기
+		return taskExecutor;
+	}
+}

--- a/src/main/java/com/wanted/sns_feed_service/config/SwaggerConfig.java
+++ b/src/main/java/com/wanted/sns_feed_service/config/SwaggerConfig.java
@@ -14,13 +14,4 @@ import io.swagger.v3.oas.annotations.info.Info;
 )
 @Configuration
 public class SwaggerConfig {
-    // @Bean
-    // public GroupedOpenApi snsOpenApi(){
-    //     String[] paths = {"/v1/**"};
-    //
-    //     return GroupedOpenApi.builder()
-    //             .group("sns")
-    //             .pathsToMatch(paths)
-    //             .build();
-    // }
 }

--- a/src/main/java/com/wanted/sns_feed_service/email/service/EmailService.java
+++ b/src/main/java/com/wanted/sns_feed_service/email/service/EmailService.java
@@ -1,0 +1,29 @@
+package com.wanted.sns_feed_service.email.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmailService {
+	@Value("${spring.mail.username}")
+	private String ADMIN_ADDRESS;
+	private final JavaMailSender mailSender;
+
+	@Async // 비동기
+	public void sendEmail(String email, String userName, String tempCode) {
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(email);
+		message.setFrom(ADMIN_ADDRESS);
+		message.setSubject(userName+"님의 임시 인증코드 안내 메일입니다.");
+		message.setText("안녕하세요 "+userName+"님의 임시 인증 코드는 [" + tempCode +"] 입니다. \n 최초 로그인 시 인증 코드를 입력해주세요.");
+		mailSender.send(message);
+	}
+}

--- a/src/main/java/com/wanted/sns_feed_service/email/service/EmailService.java
+++ b/src/main/java/com/wanted/sns_feed_service/email/service/EmailService.java
@@ -17,7 +17,7 @@ public class EmailService {
 	private String ADMIN_ADDRESS;
 	private final JavaMailSender mailSender;
 
-	@Async // 비동기
+	@Async("taskExecutor1") // 비동기
 	public void sendEmail(String email, String userName, String tempCode) {
 		SimpleMailMessage message = new SimpleMailMessage();
 		message.setTo(email);

--- a/src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java
@@ -15,6 +15,7 @@ import com.wanted.sns_feed_service.member.service.MemberService;
 import com.wanted.sns_feed_service.rsData.RsData;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -33,12 +34,15 @@ public class MemberController {
 	@Data
 	public static class SignupRequest {
 		@NotBlank(message = "id를 입력해주세요")
+		@Schema(description = "사용자 계정", example = "user123")
 		private String account;
 		@NotBlank(message = "pw를 입력해주세요")
 		@Pattern(regexp = "^(?![0-9]{10,}$)(?!.*(.)\\1{2,}).{10,}$", message = "비밀번호는 10자 이상 입력해야 하며, 숫자로만 이루어 질 수 없으며 3회 이상 연속되는 문자를 사용할 수 없습니다.")
+		@Schema(description = "사용자 비밀번호 (10자 이상, 숫자만으로 구성 불가, 3회 이상 연속되는 문자 사용 불가)", example = "password123")
 		private String password;
 		@Email(message = "올바른 이메일 형식을 입력하세요")
 		@NotBlank(message = "이메일을 입력해주세요")
+		@Schema(description = "사용자 이메일", example = "user123@example.com")
 		private String email;
 	}
 
@@ -54,7 +58,8 @@ public class MemberController {
 			return RsData.of("F-1", errorMessages.get(0));
 		}
 		// 입력 이상 없다면 계정 가입
-		RsData rsData = memberService.join(signupRequest.getAccount(), signupRequest.getPassword(), signupRequest.getEmail());
+		RsData rsData = memberService.join(signupRequest.getAccount(), signupRequest.getPassword(),
+			signupRequest.getEmail());
 
 		return rsData;
 	}

--- a/src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java
@@ -64,4 +64,34 @@ public class MemberController {
 		return rsData;
 	}
 
+	@Data
+	public static class SignInRequest {
+		@NotBlank(message = "id를 입력해주세요")
+		@Schema(description = "사용자 계정", example = "user123")
+		private String account;
+		@NotBlank(message = "pw를 입력해주세요")
+		@Schema(description = "사용자 비밀번호 (10자 이상, 숫자만으로 구성 불가, 3회 이상 연속되는 문자 사용 불가)", example = "password129")
+		private String password;
+
+		@Schema(description = "최초 로그인 시 이메일 인증 코드", example = "000000")
+		private String tempCode = "";
+	}
+
+	@PostMapping("/signin")
+	@Operation(summary = "JWT 발급")
+	public RsData signIn(@Valid @RequestBody SignInRequest signInRequest, BindingResult bindingResult) {
+		// 요청 객체에서 입력하지 않은 부분이 있다면 메세지를 담아서 RsData 객체 바로 리턴
+		if (bindingResult.hasErrors()) {
+			List<String> errorMessages = bindingResult.getAllErrors()
+				.stream()
+				.map(error -> error.getDefaultMessage())
+				.collect(Collectors.toList());
+			return RsData.of("F-1", errorMessages.get(0));
+		}
+
+		RsData<String> rsData = memberService.login(signInRequest.getAccount(), signInRequest.getPassword(), signInRequest.getTempCode());
+
+		return rsData;
+	}
+
 }

--- a/src/main/java/com/wanted/sns_feed_service/member/entity/Member.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/entity/Member.java
@@ -30,4 +30,5 @@ public class Member {
 	@Email(message = "올바른 이메일 형식을 입력하세요")
 	private String email;
 	private String accessToken;
+	private Integer tempCode;
 }

--- a/src/main/java/com/wanted/sns_feed_service/member/service/MemberService.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/service/MemberService.java
@@ -2,6 +2,10 @@ package com.wanted.sns_feed_service.member.service;
 
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +24,10 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final JwtProvider jwtProvider;
 
+	private final JavaMailSender mailSender;
+	@Value("${spring.mail.username}")
+	private String ADMIN_ADDRESS;
+
 	@Transactional
 	public RsData join(String account, String password, String email) {
 		Optional<Member> opMember = memberRepository.findByAccount(account);
@@ -27,15 +35,35 @@ public class MemberService {
 			return RsData.of("F-1", "이미 가입한 Id가 있습니다.");
 		}
 
+		// 인증코드 6자리 발급 및 저장
+		int temp = createNumber();
+
 		Member member = Member.builder()
 			.account(account)
 			.password(Ut.encrypt.encryptPW(password))
 			.email(email)
+			.tempCode(temp)
 			.build();
 
 		memberRepository.save(member);
+		// 메일 발송
+		sendEmail(email, account, Integer.toString(temp));
 
-		return RsData.of("S-1", "회원가입 완료, 로그인 후 이용해주세요!");
+		return RsData.of("S-1", "회원가입 완료 최초 로그인 시 이메일 인증 코드를 확인하고 입력해주세요");
+	}
+
+	@Async // 비동기
+	public void sendEmail(String email, String userName, String tempPW) {
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(email);
+		message.setFrom(ADMIN_ADDRESS);
+		message.setSubject(userName+"님의 임시 인증코드 안내 메일입니다.");
+		message.setText("안녕하세요 "+userName+"님의 임시 인증 코드는 [" + tempPW +"] 입니다. \n 최초 로그인 시 인증 코드를 입력해주세요.");
+		mailSender.send(message);
+	}
+
+	public int createNumber(){
+		return (int)(Math.random() * (90000)) + 100000;// (int) Math.random() * (최댓값-최소값+1) + 최소값
 	}
 
 }

--- a/src/main/java/com/wanted/sns_feed_service/member/service/MemberService.java
+++ b/src/main/java/com/wanted/sns_feed_service/member/service/MemberService.java
@@ -53,12 +53,12 @@ public class MemberService {
 	}
 
 	@Async // 비동기
-	public void sendEmail(String email, String userName, String tempPW) {
+	public void sendEmail(String email, String userName, String tempCode) {
 		SimpleMailMessage message = new SimpleMailMessage();
 		message.setTo(email);
 		message.setFrom(ADMIN_ADDRESS);
 		message.setSubject(userName+"님의 임시 인증코드 안내 메일입니다.");
-		message.setText("안녕하세요 "+userName+"님의 임시 인증 코드는 [" + tempPW +"] 입니다. \n 최초 로그인 시 인증 코드를 입력해주세요.");
+		message.setText("안녕하세요 "+userName+"님의 임시 인증 코드는 [" + tempCode +"] 입니다. \n 최초 로그인 시 인증 코드를 입력해주세요.");
 		mailSender.send(message);
 	}
 

--- a/src/main/java/com/wanted/sns_feed_service/rsData/RsData.java
+++ b/src/main/java/com/wanted/sns_feed_service/rsData/RsData.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class RsData<T> {
 	private String resultCode;
 	private String msg;

--- a/src/main/resources/application-secret.yml.template
+++ b/src/main/resources/application-secret.yml.template
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/'DB명'
+    username: '계정명'
+    password: '비밀번호'
+
+  mail:
+    host: smtp.naver.com
+    port: '포트번호'
+    username: '계정명@naver.com'
+    password: '네이버계정 비밀번호'
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.ssl.enable: true
+      mail.smtp.ssl.trust: smtp.naver.com
+      mail.smtp.starttls.enable: true
+
+custom:
+  jwt:
+    secretKey: '시크릿키'

--- a/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
@@ -117,7 +117,7 @@ public class MemberControllerTests {
 	}
 
 	@Test
-	@DisplayName("여러번 로그인 해도 아직 토큰이 유효하다면 동일한 토큰을 발급한다.")
+	@DisplayName("로그인 시 JWT 발급 테스트")
 	void t4() throws Exception {
 		// When
 		ResultActions resultActions = mvc

--- a/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
@@ -46,7 +46,7 @@ public class MemberControllerTests {
 		resultActions
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
-			.andExpect(jsonPath("$.msg").value("회원가입 완료, 로그인 후 이용해주세요!"));
+			.andExpect(jsonPath("$.msg").value("회원가입 완료 최초 로그인 시 이메일 인증 코드를 확인하고 입력해주세요"));
 	}
 
 	@Test

--- a/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
@@ -16,12 +16,19 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.sns_feed_service.member.entity.Member;
+import com.wanted.sns_feed_service.member.repository.MemberRepository;
+import static org.assertj.core.api.Assertions.*;
+
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 public class MemberControllerTests {
 	@Autowired
 	private MockMvc mvc;
+
+	@Autowired
+	private MemberRepository memberRepository;
 
 	@Test
 	@DisplayName("POST /member/signup 은 회원가입을 처리한다.")
@@ -34,7 +41,7 @@ public class MemberControllerTests {
 						{
 						    "account": "puar12",
 						    "password": "cjfgus2514",
-						    "email": "aaaaa@naver.com"
+						    "email": "r4560798@naver.com"
 						}
 						""".stripIndent())
 					// JSON 형태로 보내겠다
@@ -47,6 +54,10 @@ public class MemberControllerTests {
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
 			.andExpect(jsonPath("$.msg").value("회원가입 완료 최초 로그인 시 이메일 인증 코드를 확인하고 입력해주세요"));
+
+		// 인증 코드 값이 들어있는지 확인
+		Member member = memberRepository.findByAccount("puar12").get();
+		assertThat(member.getTempCode()).isNotNull();
 	}
 
 	@Test


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️관련 이슈[#]
close #12 
close #22 
### 📑 개요
- 회원 가입 시 입력한 이메일로 인증 코드 6자리를 발송하여 이메일 인증 기능을 할 수 있도록 구현하였습니다.
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- **src/main/java/com/wanted/sns_feed_service/SnsFeedServiceApplication.java**
  - 이메일 발송을 비동기로 처리할 수 있도록 어노테이션을 추가하였습니다.

- **src/main/java/com/wanted/sns_feed_service/config/AsyncConfig.java**
  - 스레드풀을 사용하기 위한  ThreadPoolTaskExecutor 객체를 설정하고 Bean으로 등록합니다.

- **src/main/java/com/wanted/sns_feed_service/email/service/EmailService.java**
  - 이메일 처리 메서드를 분리하였습니다.
  - @Async 동작 원리가 Proxy 객체를 통해야 비동기로 동작하기에, 빈으로 등록한 다른 객체에서 호출해야 비동기적으로 사용할 수 있기에 분리하였습니다
  - endEmail(String email, String userName, String tempCode) : 사용자에게 tempCode 보내는 비동기 함수
  
- **src/main/java/com/wanted/sns_feed_service/member/entity/Member.java**
  - 임시 번호를 저장할 필드를 구성하였습니다.
  - 생각한 로그인 과정 : 인증코드 속성을 선택, ID/PW는 필수로 설정
    -  최초 로그인 : `ID/PW/인증코드` POST를 받고 -> 인증코드가 맞으면 JWT발급, 인증코드 필드값 NULL 설정
    - 2번째 로그인 : `ID/PW` POST로 받고 -> DB에서 꺼내온인증코드 필드 값이 NULL이면 JWT 발급 / NULL이 아니면 이메일 인증 필요한 계정이라 로그인 거부
![image](https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/126079049/8cb32c42-b565-44dc-b9b1-743eddb8ed42) 

- **src/main/java/com/wanted/sns_feed_service/member/controller/MemberController.java**
  - Swagger 문서 description 등 표기 내용 수정
![image](https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/126079049/81ff8916-884c-406a-a22c-d67615be95e8)

![image](https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/126079049/a1b7a0ad-cdd7-4a22-95e9-5ffd7ae70dd5)
- **src/main/java/com/wanted/sns_feed_service/member/service/MemberService.java**
  - createNumber() : 인증 코드 6자리 구성 메서드
  - 비동기 동작을 위한 emailService 객체를 활용해 메서드 호출

-------
### 로그인 기능 구현(JWT 발급)
- **src/main/java/com/wanted/sns_feed_service/member/service/MemberService.java**
  - login(String account, String password, String tempCode) 메서드 구현
    - 예외 처리 (ID/PW 일치 하지 않을 때 바로 입구컷)
    - 이메일 인증이 필요한 경우(Member 객체에 tempCode가 Null이 아니라면)
      - 인증코드 처리(tempCode값을 null로 업데이트)
    - Member 객체에 JWT가 없거나 유효기간이 지났다면 새로 반환
    - JWT가 있다면 그대로 반환
    - @Transactional 어노테이션 있어서 더티체킹으로  save 명시 안해줘도 변하겠지만, 의도 전달의 명확한 메서드 구현을 위해 save를 명시하였습니다.

- **src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java**
  - test 4: 로그인 시 토큰 발행 테스트
  - test 5 : 최초 로그인, 두번째 로그인 시에도 토큰 값이 같은지 확인 

## 📷 스크린샷
![image](https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/126079049/654bdb34-788c-45cb-865e-25d3a3bbc36d)
- 발송 잘 됩니다 ㅎ

## 👀 기타
- 저번 PR에 swagger 설정에 불 필요한 부분 삭제하였습니다.
- 시크릿 yml 내용 PR 승인 시 디스코드 채팅방에 남겨두겠습니다.
- 리팩토링 부분 [노션 페이지](https://www.notion.so/Async-e3c46a83efd144f3a0f270e46e09790d?pvs=4) 에 자세히 설명해두었으니 한번 읽어보세요!