### PR TITLE
[Docs] Swagger 문서 및 권한이 필요한 인터셉터 예외처리

### DIFF
--- a/src/main/java/com/wanted/sns_feed_service/config/MvcConfig.java
+++ b/src/main/java/com/wanted/sns_feed_service/config/MvcConfig.java
@@ -3,6 +3,8 @@ package com.wanted.sns_feed_service.config;
 import com.wanted.sns_feed_service.interceptor.AuthorizationInterceptor;
 import com.wanted.sns_feed_service.resolver.LoginUserResolver;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -18,7 +20,7 @@ public class MvcConfig implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry){
-    registry.addInterceptor(authorizationInterceptor).excludePathPatterns("/member/**");
+    registry.addInterceptor(authorizationInterceptor).excludePathPatterns("/member/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html");
   }
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/java/com/wanted/sns_feed_service/config/SwaggerConfig.java
+++ b/src/main/java/com/wanted/sns_feed_service/config/SwaggerConfig.java
@@ -1,17 +1,24 @@
 package com.wanted.sns_feed_service.config;
 
-import org.springdoc.core.models.GroupedOpenApi;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 
 @OpenAPIDefinition(
         info = @Info(title = "sns",
-                description = "sns api - personal project",
                 version = "v1")
 )
 @Configuration
+@SecurityScheme(
+	name = "bearerAuth",
+	type = SecuritySchemeType.HTTP,
+	bearerFormat = "JWT",
+	scheme = "bearer"
+)
 public class SwaggerConfig {
 }

--- a/src/main/java/com/wanted/sns_feed_service/exceptionHandler/ApiGlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/sns_feed_service/exceptionHandler/ApiGlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package com.wanted.sns_feed_service.exceptionHandler;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.stream.Collectors;
+
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+
+import com.wanted.sns_feed_service.rsData.RsData;
+
+@RestControllerAdvice(annotations = {RestController.class}) // 모든 @RestController 에서 발생한 예외에 대한 제어권을 가로챈다.
+public class ApiGlobalExceptionHandler {
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	@ResponseStatus(NOT_FOUND)
+	public RsData<String> errorHandler(MethodArgumentNotValidException exception) {
+		String msg = exception
+			.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getDefaultMessage)
+			.collect(Collectors.joining("/"));
+
+		String data = exception
+			.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getCode)
+			.collect(Collectors.joining("/"));
+
+		return RsData.of("F-MethodArgumentNotValidException", msg, data);
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	@ResponseStatus(INTERNAL_SERVER_ERROR)
+	public RsData<String> errorHandler(RuntimeException exception) {
+		String msg = exception.getClass().toString();
+
+		String data = exception.getMessage();
+
+		return RsData.of("F-RuntimeException", msg, data);
+	}
+
+	@ExceptionHandler(AuthenticationException.class)
+	@ResponseStatus(UNAUTHORIZED) // 예외에 따른 HTTP 상태 코드 설정
+	public RsData<String> handleAuthenticationException(AuthenticationException exception) {
+		String msg = exception.getMessage(); // 예외 메시지 추출
+
+		// RsData.of 메서드 호출
+		return RsData.of("F-AuthenticationException", msg);
+	}
+}

--- a/src/main/java/com/wanted/sns_feed_service/exceptionHandler/AuthenticationException.java
+++ b/src/main/java/com/wanted/sns_feed_service/exceptionHandler/AuthenticationException.java
@@ -1,0 +1,7 @@
+package com.wanted.sns_feed_service.exceptionHandler;
+
+public class AuthenticationException extends RuntimeException {
+	public AuthenticationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/wanted/sns_feed_service/feed/controller/FeedController.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/controller/FeedController.java
@@ -9,6 +9,7 @@ import com.wanted.sns_feed_service.response.FeedDetailResponse;
 import com.wanted.sns_feed_service.response.ResResult;
 import com.wanted.sns_feed_service.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -23,6 +24,7 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 @RequestMapping("/feed")
 @Tag(name = "FeedController", description = "피드 컨트롤러")
+@SecurityRequirement(name = "bearerAuth")
 public class FeedController {
 
     private final FeedService feedService;
@@ -97,9 +99,10 @@ public class FeedController {
      */
 
     @GetMapping("/statistics")
+    @Operation(summary = "통계 자료 조회", description = "통계 자료를 조회합니다.")
     public ResponseEntity<CommonResponse> getFeedByHashtag(
             @RequestParam(value = "hashtag", required = false, defaultValue = "기본값") String hashtag,
-            @RequestParam(value = "type", required = true) String type,
+            @RequestParam(value = "type") String type,
             @RequestParam(value = "start", required = false) LocalDate start,
             @RequestParam(value = "end", required = false) LocalDate end,
             @RequestParam(value = "value", required = false, defaultValue = "count") String value

--- a/src/main/java/com/wanted/sns_feed_service/initData/NotProd.java
+++ b/src/main/java/com/wanted/sns_feed_service/initData/NotProd.java
@@ -32,6 +32,7 @@ public class NotProd {
 				.account("user1")
 				.password(password)
 				.email("user1@test.com")
+				.accessToken("eyJhbGciOiJIUzUxMiJ9.eyJib2R5Ijoie1wiaWRcIjoxLFwiYWNjb3VudFwiOlwidXNlcjFcIn0iLCJleHAiOjE3MzA3ODI3OTd9.RiMDTPrgdefq0uFTac1sXeF6U1HVMu4nr3teH48qQc1HipbalcnuqqJSmIrEGb3jiT1x-0j2MvIWeHFWgFhHrA")
 				.build();
 
 			Member user2 = Member.builder()

--- a/src/main/java/com/wanted/sns_feed_service/initData/NotProd.java
+++ b/src/main/java/com/wanted/sns_feed_service/initData/NotProd.java
@@ -32,6 +32,7 @@ public class NotProd {
 				.account("user1")
 				.password(password)
 				.email("user1@test.com")
+				// 24-11-06 까지 유효
 				.accessToken("eyJhbGciOiJIUzUxMiJ9.eyJib2R5Ijoie1wiaWRcIjoxLFwiYWNjb3VudFwiOlwidXNlcjFcIn0iLCJleHAiOjE3MzA3ODI3OTd9.RiMDTPrgdefq0uFTac1sXeF6U1HVMu4nr3teH48qQc1HipbalcnuqqJSmIrEGb3jiT1x-0j2MvIWeHFWgFhHrA")
 				.build();
 

--- a/src/main/java/com/wanted/sns_feed_service/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/wanted/sns_feed_service/interceptor/AuthorizationInterceptor.java
@@ -1,63 +1,74 @@
 package com.wanted.sns_feed_service.interceptor;
 
-import com.wanted.sns_feed_service.jwt.JwtProvider;
-import com.wanted.sns_feed_service.member.entity.Member;
-import com.wanted.sns_feed_service.member.repository.MemberRepository;
-import com.wanted.sns_feed_service.resolver.LoginMember;
-import com.wanted.sns_feed_service.resolver.LoginMemberContext;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import java.util.Optional;
+import com.wanted.sns_feed_service.exceptionHandler.AuthenticationException;
+import com.wanted.sns_feed_service.jwt.JwtProvider;
+import com.wanted.sns_feed_service.member.entity.Member;
+import com.wanted.sns_feed_service.member.repository.MemberRepository;
+import com.wanted.sns_feed_service.resolver.LoginMemberContext;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class AuthorizationInterceptor implements HandlerInterceptor {
-  private final JwtProvider jwtProvider;
-  private final MemberRepository memberRepository;
-  private final LoginMemberContext loginMemberContext;
-  @Override
-  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-    String token = extractToken(request);
-    if(!jwtProvider.verify(token))
-      return false;
-    Optional<Member> memberOptional=extractMember(token);
-    if(memberOptional.isEmpty())
-      return false;
-    if(!verifyAccessToken(token,memberOptional))
-      return false;
-    //사용자 정보 context 등록
-    registerLoginMemberContext(memberOptional);
-    return HandlerInterceptor.super.preHandle(request, response, handler);
-  }
+	private final JwtProvider jwtProvider;
+	private final MemberRepository memberRepository;
+	private final LoginMemberContext loginMemberContext;
 
-  @Override
-  public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
-    releaseLoginMemberContext();
-    HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
-  }
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		String token = extractToken(request);
+		if (token == null)
+			throw new AuthenticationException("JWT를 요청 헤더에 넣어주세요");
+		token = token.substring("Bearer ".length());
+		if (!jwtProvider.verify(token))
+			throw new AuthenticationException("유효하지 않은 토큰입니다.");
+		Optional<Member> memberOptional = extractMember(token);
+		if (memberOptional.isEmpty())
+			throw new AuthenticationException("존재하지 않는 사용자입니다.");
+		if (!verifyAccessToken(token, memberOptional))
+			throw new AuthenticationException("저장된 토큰 정보가 유효하지 않습니다.");
+		//사용자 정보 context 등록
+		registerLoginMemberContext(memberOptional);
+		return HandlerInterceptor.super.preHandle(request, response, handler);
+	}
 
-  private String extractToken(HttpServletRequest request){
-    return request.getHeader("Authorization");
-  }
-  private Optional<Member> extractMember(String token){
-    return memberRepository.findById(Long.valueOf((Integer)jwtProvider.getClaims(token).get("id")));
-  }
-  private boolean verifyAccessToken(String token,Optional<Member> memberOptional){
-    if(memberOptional.isEmpty())
-      return false;
-    return token.equals(memberOptional.get().getAccessToken());
-  }
+	@Override
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+		Exception ex) throws Exception {
+		releaseLoginMemberContext();
+		HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+	}
 
-  private void registerLoginMemberContext(Optional<Member> memberOptional){
-    if (memberOptional.isEmpty())
-      return;
-    loginMemberContext.save(memberOptional.get());
-  }
-  private void releaseLoginMemberContext(){
-    loginMemberContext.remove();
-  }
+	private String extractToken(HttpServletRequest request) {
+		return request.getHeader("Authorization");
+	}
+
+	private Optional<Member> extractMember(String token) {
+		return memberRepository.findById(Long.valueOf((Integer)jwtProvider.getClaims(token).get("id")));
+	}
+
+	private boolean verifyAccessToken(String token, Optional<Member> memberOptional) {
+		if (memberOptional.isEmpty())
+			throw new AuthenticationException("존재하지 않는 사용자입니다.");
+		return token.equals(memberOptional.get().getAccessToken());
+	}
+
+	private void registerLoginMemberContext(Optional<Member> memberOptional) {
+		if (memberOptional.isEmpty())
+			return;
+		loginMemberContext.save(memberOptional.get());
+	}
+
+	private void releaseLoginMemberContext() {
+		loginMemberContext.remove();
+	}
 }

--- a/src/main/java/com/wanted/sns_feed_service/interceptor/AuthorizationTestController.java
+++ b/src/main/java/com/wanted/sns_feed_service/interceptor/AuthorizationTestController.java
@@ -6,11 +6,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 @RestController
 @RequestMapping("/v1/authorization/test")
 public class AuthorizationTestController {
   @GetMapping
-  public String authorizationTest(@LoginUser LoginMember loginMember){
+  public String authorizationTest(@LoginUser @Parameter(hidden = true) LoginMember loginMember){
     return loginMember.getAccount();
   }
 }

--- a/src/test/java/com/wanted/sns_feed_service/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/wanted/sns_feed_service/feed/controller/FeedControllerTest.java
@@ -1,12 +1,10 @@
 package com.wanted.sns_feed_service.feed.controller;
 
-import com.wanted.sns_feed_service.feed.entity.Feed;
-import com.wanted.sns_feed_service.feed.repository.FeedRepository;
-import com.wanted.sns_feed_service.hashTag.entity.HashTag;
-import com.wanted.sns_feed_service.hashTag.repository.HashTagRepository;
-import jakarta.transaction.Transactional;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
+import static com.wanted.sns_feed_service.feed.entity.Type.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,11 +16,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import static com.wanted.sns_feed_service.feed.entity.Type.INSTAGRAM;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.wanted.sns_feed_service.feed.entity.Feed;
+import com.wanted.sns_feed_service.feed.repository.FeedRepository;
+import com.wanted.sns_feed_service.hashTag.entity.HashTag;
+import com.wanted.sns_feed_service.hashTag.repository.HashTagRepository;
+import com.wanted.sns_feed_service.member.entity.Member;
+import com.wanted.sns_feed_service.member.repository.MemberRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -30,235 +32,255 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 class FeedControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
-    @Autowired
-    FeedRepository feedRepository;
-    @Autowired
-    HashTagRepository hashTagRepository;
+	@Autowired
+	MockMvc mockMvc;
+	@Autowired
+	FeedRepository feedRepository;
+	@Autowired
+	HashTagRepository hashTagRepository;
 
-    @BeforeEach
-    void init(){
-        // given
+	@Autowired
+	MemberRepository memberRepository;
 
-        // 태그 추가
-        HashTag tag = HashTag.builder()
-                .name("테스트테그3")
-                .build();
-        hashTagRepository.save(tag);
+    Member user1;
+    String user1Token;
 
-        // 피드 추가
-        Feed insta = Feed.builder().contentId("test").type(INSTAGRAM).title("test").content("test").build();
+	@BeforeEach
+	void init() {
+		// given
 
-        insta.addTag(tag);
+		// 태그 추가
+		HashTag tag = HashTag.builder()
+			.name("테스트테그3")
+			.build();
+		hashTagRepository.save(tag);
 
-        feedRepository.save(insta);
-    }
+		// 피드 추가
+		Feed insta = Feed.builder().contentId("test").type(INSTAGRAM).title("test").content("test").build();
 
-    @DisplayName("해시 테그 검색 테스트, hashtag 가 정확하게 일치하지 않으면 데이터가 0건")
-    @Test
-    void 해시_테그_검색_실패() throws Exception {
+		insta.addTag(tag);
 
-        //when, then
-        mockMvc.perform(get("/feed")
-                        .param("hashtag", "테스트")
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.size()").value(0))
-                .andDo(print());
-    }
+		feedRepository.save(insta);
 
-    @DisplayName("해시 테그 검색 테스트")
-    @Test
-    void 해시_테그_검색() throws Exception {
+        user1 = memberRepository.findByAccount("user1").get();
+        user1Token = user1.getAccessToken();
+	}
 
-        //when, then
-        mockMvc.perform(get("/feed")
-                        .param("hashtag", "테스트태그1")
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.size()").value(10))
-                .andDo(print());
-    }
+	@DisplayName("해시 테그 검색 테스트, hashtag 가 정확하게 일치하지 않으면 데이터가 0건")
+	@Test
+	void 해시_테그_검색_실패() throws Exception {
 
-    @DisplayName("타입_검색 테스트")
-    @Test
-    void 타입_검색() throws Exception {
+		//when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("hashtag", "테스트")
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.size()").value(0))
+			.andDo(print());
+	}
 
-        //when, then
-        mockMvc.perform(get("/feed")
-                        .param("type", "INSTAGRAM")
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.size()").value(10))
-                .andExpect(jsonPath("$.data.content[0].type").value("INSTAGRAM"))
-                .andDo(print());
-    }
+	@DisplayName("해시 테그 검색 테스트")
+	@Test
+	void 해시_테그_검색() throws Exception {
 
-    @DisplayName("정렬 테스트 - created_at, 내림차순 ")
-    @Test
-    void 정렬_테스트1() throws Exception {
+		//when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("hashtag", "테스트태그1")
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.size()").value(10))
+			.andDo(print());
+	}
 
-        //when, then
-        mockMvc.perform(get("/feed")
-                        .param("order_by", "DESC") // 가장 최근에 생성한 피드가 가장 위에 오게 됨.
-                        .param("order_type", "created_at")
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content[0].content").value("test"))
-                .andDo(print());
-    }
+	@DisplayName("타입_검색 테스트")
+	@Test
+	void 타입_검색() throws Exception {
 
-    @DisplayName("정렬 테스트 - created_at, 오름차순 ")
-    @Test
-    void 정렬_테스트2() throws Exception {
+		//when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("type", "INSTAGRAM")
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.size()").value(10))
+			.andExpect(jsonPath("$.data.content[0].type").value("INSTAGRAM"))
+			.andDo(print());
+	}
 
-        //when, then
-        mockMvc.perform(get("/feed")
-                        .param("order_by", "asc") // 가장 오래전에 생성한 피드가 가장 위에 오게 됨.
-                        .param("order_type", "created_at")
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content[0].content").value("인스타 테스트 피드0"))
-                .andDo(print());
-    }
+	@DisplayName("정렬 테스트 - created_at, 내림차순 ")
+	@Test
+	void 정렬_테스트1() throws Exception {
 
-    @DisplayName("검색어 테스트")
-    @Test
-    void 검색어_테스트() throws Exception {
+		//when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("order_by", "DESC") // 가장 최근에 생성한 피드가 가장 위에 오게 됨.
+				.param("order_type", "created_at")
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content[0].content").value("test"))
+			.andDo(print());
+	}
 
-        //when, then
-        mockMvc.perform(get("/feed")
-                        .param("search_by", "title") // title 로 검색
-                        .param("search", "9")
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.size()").value(4)) // title 에 9가 들어간건 4개 뿐임
-                .andDo(print());
-    }
+	@DisplayName("정렬 테스트 - created_at, 오름차순 ")
+	@Test
+	void 정렬_테스트2() throws Exception {
 
+		//when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("order_by", "asc") // 가장 오래전에 생성한 피드가 가장 위에 오게 됨.
+				.param("order_type", "created_at")
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content[0].content").value("인스타 테스트 피드0"))
+			.andDo(print());
+	}
 
-    @DisplayName("검색어 테스트 - search_by 를 생략하면 title + content 으로 검색")
-    @Test
-    @Transactional
-    void 검색어_테스트2() throws Exception {
+	@DisplayName("검색어 테스트")
+	@Test
+	void 검색어_테스트() throws Exception {
 
-        // given
+		//when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("search_by", "title") // title 로 검색
+				.param("search", "9")
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.size()").value(4)) // title 에 9가 들어간건 4개 뿐임
+			.andDo(print());
+	}
 
-        // 태그 추가
-        HashTag tag = HashTag.builder()
-                .name("instagram")
-                .build();
-        hashTagRepository.save(tag);
+	@DisplayName("검색어 테스트 - search_by 를 생략하면 title + content 으로 검색")
+	@Test
+	@Transactional
+	void 검색어_테스트2() throws Exception {
 
-        // 피드 추가
-        Feed insta1 = Feed.builder().contentId("instagram100").type(INSTAGRAM).title("맛있는").content("꿔바로우").build();
-        Feed insta2 = Feed.builder().contentId("instagram200").type(INSTAGRAM).title("꿔바로우").content("좋아하세요?").build();
+		// given
 
-        insta1.addTag(tag);
-        insta2.addTag(tag);
+		// 태그 추가
+		HashTag tag = HashTag.builder()
+			.name("instagram")
+			.build();
+		hashTagRepository.save(tag);
 
-        feedRepository.save(insta1);
-        feedRepository.save(insta2);
+		// 피드 추가
+		Feed insta1 = Feed.builder().contentId("instagram100").type(INSTAGRAM).title("맛있는").content("꿔바로우").build();
+		Feed insta2 = Feed.builder().contentId("instagram200").type(INSTAGRAM).title("꿔바로우").content("좋아하세요?").build();
 
-        //when, then
-        mockMvc.perform(get("/feed")
-                        .param("search", "꿔바로우")
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.size()").value(2))
-                .andDo(print());
-    }
+		insta1.addTag(tag);
+		insta2.addTag(tag);
 
-    @DisplayName("글자수 20자 제한 테스트")
-    @Test
-    @Transactional
-    void 글자수_20자_제한_테스트() throws Exception {
+		feedRepository.save(insta1);
+		feedRepository.save(insta2);
 
-        // given
+		//when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("search", "꿔바로우")
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.size()").value(2))
+			.andDo(print());
+	}
 
-        // 태그 추가
-        HashTag tag = HashTag.builder()
-                .name("타짜")
-                .build();
-        hashTagRepository.save(tag);
+	@DisplayName("글자수 20자 제한 테스트")
+	@Test
+	@Transactional
+	void 글자수_20자_제한_테스트() throws Exception {
 
-        // 피드 추가
-        String longContent = "싸늘하다. 가슴에 비수가 날아와 꽂힌다. 하지만 걱정하지 마라. 손은 눈보다 빠르니까.";
-        String shortContent = "묻고 더블로 가!";
+		// given
 
-        Feed insta1 = Feed.builder().contentId("타짜1").type(INSTAGRAM).title("타짜")
-                .content(longContent).build();
+		// 태그 추가
+		HashTag tag = HashTag.builder()
+			.name("타짜")
+			.build();
+		hashTagRepository.save(tag);
 
-        Feed insta2 = Feed.builder().contentId("타짜2").type(INSTAGRAM).title("타짜")
-                .content(shortContent).build();
+		// 피드 추가
+		String longContent = "싸늘하다. 가슴에 비수가 날아와 꽂힌다. 하지만 걱정하지 마라. 손은 눈보다 빠르니까.";
+		String shortContent = "묻고 더블로 가!";
 
-        insta1.addTag(tag);
-        insta2.addTag(tag);
+		Feed insta1 = Feed.builder().contentId("타짜1").type(INSTAGRAM).title("타짜")
+			.content(longContent).build();
 
-        feedRepository.save(insta1);
-        feedRepository.save(insta2);
+		Feed insta2 = Feed.builder().contentId("타짜2").type(INSTAGRAM).title("타짜")
+			.content(shortContent).build();
 
-        // when, then
-        mockMvc.perform(get("/feed")
-                        .param("hashtag", "타짜") // tag 로 검색
-                        .param("order_target","create_at") // 생성순
-                        .param("order_by","asc") // 먼저 생성된 데이터가 가장 상단에 위치
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].content") // 목록의 첫번째 content 를 가져옴
-                        .value(longContent.substring(0, 20) + "...")) // 글자 수가 20을 넘어가면 이후 글자는 생략됨.
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].content")
-                        .value(shortContent)) // 글자 수가 20을 넘어가지 않을 때는 생략 없음.
-                .andDo(print());
-    }
+		insta1.addTag(tag);
+		insta2.addTag(tag);
 
-    @DisplayName("통합 검색 테스트")
-    @Test
-    void 통합_검색_테스트() throws Exception {
+		feedRepository.save(insta1);
+		feedRepository.save(insta2);
 
-        //when, then
-        mockMvc.perform(get("/feed")
-                        .param("hashtag", "테스트테그3") // 해시테그로 검색
-                        .param("search", "test") // 검색어
-                        .param("order_by", "desc") // 정렬 순서
-                        .param("page_count", "1") // 하나의 page 에 담길 데이터 수
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1)) // 총 검색된 데이터 건 수
-                .andExpect(jsonPath("$.data.totalPages").value(1)) // 총 페이지 수
-                .andExpect(jsonPath("$.data.content[0].content").value("test"))
-                .andDo(print());
-    }
+		// when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("hashtag", "타짜") // tag 로 검색
+				.param("order_target", "create_at") // 생성순
+				.param("order_by", "asc") // 먼저 생성된 데이터가 가장 상단에 위치
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].content") // 목록의 첫번째 content 를 가져옴
+				.value(longContent.substring(0, 20) + "...")) // 글자 수가 20을 넘어가면 이후 글자는 생략됨.
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].content")
+				.value(shortContent)) // 글자 수가 20을 넘어가지 않을 때는 생략 없음.
+			.andDo(print());
+	}
 
-    @DisplayName("통합 검색 테스트2")
-    @Test
-    void 통합_검색_테스트2() throws Exception {
+	@DisplayName("통합 검색 테스트")
+	@Test
+	void 통합_검색_테스트() throws Exception {
 
-        //when, then
-        mockMvc.perform(get("/feed")
-                        .param("type", "INSTAGRAM") // 타입으로 검색
-                        .param("search_by", "title") // 타이틀로 검색
-                        .param("search", "틀0") // 검색어
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1)) // 총 검색된 데이터 건 수
-                .andExpect(jsonPath("$.data.content[0].title").value("인스타 테스트 타이틀0"))
-                .andDo(print());
-    }
+		//when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("hashtag", "테스트테그3") // 해시테그로 검색
+				.param("search", "test") // 검색어
+				.param("order_by", "desc") // 정렬 순서
+				.param("page_count", "1") // 하나의 page 에 담길 데이터 수
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.totalElements").value(1)) // 총 검색된 데이터 건 수
+			.andExpect(jsonPath("$.data.totalPages").value(1)) // 총 페이지 수
+			.andExpect(jsonPath("$.data.content[0].content").value("test"))
+			.andDo(print());
+	}
 
-    @DisplayName("findFeed: 게시물 상세 조회에 성공한다.")
-    @Test
-    public void findFeed() throws Exception {
-        // given
-        final String url = "/feed/{id}";
+	@DisplayName("통합 검색 테스트2")
+	@Test
+	void 통합_검색_테스트2() throws Exception {
 
-        // when
-        final ResultActions resultActions = mockMvc.perform(get(url, 1));
+		//when, then
+		mockMvc.perform(get("/feed")
+				.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+				.param("type", "INSTAGRAM") // 타입으로 검색
+				.param("search_by", "title") // 타이틀로 검색
+				.param("search", "틀0") // 검색어
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.totalElements").value(1)) // 총 검색된 데이터 건 수
+			.andExpect(jsonPath("$.data.content[0].title").value("인스타 테스트 타이틀0"))
+			.andDo(print());
+	}
 
-        // then
-        resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.contentId").value("instagram0"))
-                .andExpect(jsonPath("$.viewCount").value(1));
-    }
+	@DisplayName("findFeed: 게시물 상세 조회에 성공한다.")
+	@Test
+	public void findFeed() throws Exception {
+		// given
+		final String url = "/feed/{id}";
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(get(url, 1)
+			.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+		);
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.contentId").value("instagram0"))
+			.andExpect(jsonPath("$.viewCount").value(1));
+	}
 }

--- a/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java
@@ -45,7 +45,7 @@ public class MemberControllerTests {
 						{
 						    "account": "puar12",
 						    "password": "cjfgus2514",
-						    "email": "r4560798@naver.com"
+						    "email": "r4560798@test.com"
 						}
 						""".stripIndent())
 					// JSON 형태로 보내겠다
@@ -125,7 +125,7 @@ public class MemberControllerTests {
 				post("/member/signin")
 					.content("""
                     {
-                        "account": "user1",
+                        "account": "user2",
                         "password": "1234"
                     }
                     """.stripIndent())
@@ -151,7 +151,7 @@ public class MemberControllerTests {
 				post("/member/signin")
 					.content("""
                     {
-                        "account": "user1",
+                        "account": "user2",
                         "password": "1234"
                     }
                     """.stripIndent())
@@ -181,7 +181,7 @@ public class MemberControllerTests {
 				post("/member/signin")
 					.content("""
                     {
-                        "account": "user1",
+                        "account": "user2",
                         "password": "1234"
                     }
                     """.stripIndent())


### PR DESCRIPTION
## 🌿 PR타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️관련 이슈[#]
close #31 
### 📑 개요
- Swagger 문서에 Bearer 형식으로 JWT를 받을 수 있도록 수정하였습니다.
- Test Case에 user1에 대한 토큰을 추가하여 실패하던 테스트케이스를 수정하였습니다.
- 예외 처리 양식을 RsData 형식으로 통일하였습니다.
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- **src/main/java/com/wanted/sns_feed_service/config/MvcConfig.java**
  -  excludePathPatterns에 Swagger 링크를 추가하여 Swagger 문서 확인 시에 인증이 필요 없도록 수정
- **src/main/java/com/wanted/sns_feed_service/config/SwaggerConfig.java**
  - bearer 타입으로 JWT 받도록 설정 
- **src/main/java/com/wanted/sns_feed_service/exceptionHandler/ApiGlobalExceptionHandler.java**
  - 발생하는 예외 RsData 형식으로 통일

- **src/main/java/com/wanted/sns_feed_service/exceptionHandler/AuthenticationException.java**
  - JWT가 유효하지 않거나, 입력하지 않았거나 등 예외 메세지를 담을 Exception 정의
- **src/main/java/com/wanted/sns_feed_service/feed/controller/FeedController.java**
  - required 설정하지 않으면 기본값 true여서 삭제
- **src/main/java/com/wanted/sns_feed_service/initData/NotProd.java**
  - test를 위한 JWT를 발급받고 DB에 저장(유효기간 1년)

- **src/main/java/com/wanted/sns_feed_service/interceptor/AuthorizationInterceptor.java**
  - 예외에 메세지를 담아서 던저버림 -> ApiGlobalExceptionHandler에 의해 RsData로 응답
- **src/test/java/com/wanted/sns_feed_service/feed/controller/FeedControllerTest.java**
  - 요청 보낼 때 header에 토큰값 넣어서 보내도록 테스트
- **src/test/java/com/wanted/sns_feed_service/member/controller/MemberControllerTests.java**
  - user1 건들지 않기 위해 user2로 변경

## 📷 스크린샷

![image](https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/126079049/455da0df-d869-4bec-932c-3ee4d97f2836)

- 요청 헤더에 토큰을 넣지 않으면 RsData 형식으로 응답합니다(기존 무응답)
![image](https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/126079049/b6a4963d-8bfb-4655-bc92-682751b58290)
- Swagger에서 테스트 시 자물쇠 눌러서 JWT 입력 필요
- 발급 받기 위해서는 **/signin**에 로그인 시 발급

## 👀 기타
- 해당 자료 Restaurant로 가져갈게용~!