### PR TITLE
feat: 통계 API hashtag 값 없을 시 login user Acoount로 조회하도록 수정

### DIFF
--- a/src/main/java/com/wanted/sns_feed_service/feed/controller/FeedController.java
+++ b/src/main/java/com/wanted/sns_feed_service/feed/controller/FeedController.java
@@ -4,11 +4,14 @@ package com.wanted.sns_feed_service.feed.controller;
 import com.wanted.sns_feed_service.feed.FeedService;
 import com.wanted.sns_feed_service.feed.entity.Feed;
 import com.wanted.sns_feed_service.feed.entity.Type;
+import com.wanted.sns_feed_service.resolver.LoginMember;
+import com.wanted.sns_feed_service.resolver.LoginUser;
 import com.wanted.sns_feed_service.response.CommonResponse;
 import com.wanted.sns_feed_service.response.FeedDetailResponse;
 import com.wanted.sns_feed_service.response.ResResult;
 import com.wanted.sns_feed_service.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -97,16 +100,18 @@ public class FeedController {
     /**
      * 통계
      */
-
     @GetMapping("/statistics")
     @Operation(summary = "통계 자료 조회", description = "통계 자료를 조회합니다.")
     public ResponseEntity<CommonResponse> getFeedByHashtag(
-            @RequestParam(value = "hashtag", required = false, defaultValue = "기본값") String hashtag,
+            @RequestParam(value = "hashtag", required = false, defaultValue = "") String hashtag,
+            @Parameter(hidden = true) @LoginUser LoginMember loginMember,
             @RequestParam(value = "type") String type,
             @RequestParam(value = "start", required = false) LocalDate start,
             @RequestParam(value = "end", required = false) LocalDate end,
             @RequestParam(value = "value", required = false, defaultValue = "count") String value
     ) {
+        if (hashtag.equals(""))
+            hashtag = loginMember.getAccount();
         return ResponseEntity.ok(feedService.getFeeds(hashtag, type, start, end, value));
     }
 }


### PR DESCRIPTION
## 🌿 PR타입
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

## ❗️관련 이슈[#]
### 📑 개요
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- 1dfb9153
hashtag 값을 입력하지 않았을 경우 로그인한 유저의 Account로 검색하도록 API 수정

## 📷 스크린샷
user123이라는 hashtag 추가, hash_tag_feed에 1번 데이터의 태그값 user123로 변경 후 확인
![image](https://github.com/Teemo-Wanted/SNS_Feed_Service/assets/58131372/cfdc5d8f-4ee0-447b-a1ec-d50857fa390e)


## 👀 기타
